### PR TITLE
Allow apps to expose a public area

### DIFF
--- a/proxy.coffee
+++ b/proxy.coffee
@@ -105,7 +105,7 @@ class exports.CozyProxy
         @app.get '/logout', @logoutAction
         @app.get '/authenticated', @authenticatedAction
 
-        @app.all '/apps/:name/public/*', @redirectPublicAppAction
+        @app.all '/public/:name/*', @redirectPublicAppAction
         @app.all '/apps/:name/*', @redirectAppAction
         @app.all '/*', @defaultRedirectAction
         
@@ -161,7 +161,7 @@ class exports.CozyProxy
     redirectPublicAppAction: (req, res) =>
         buffer = httpProxy.buffer(req)
         appName = req.params.name
-        req.url = req.url.substring "/apps/#{appName}".length
+        req.url = req.url.substring "/public/#{appName}".length
         port = @routes[appName]
 
         if port?

--- a/test/route_test.coffee
+++ b/test/route_test.coffee
@@ -61,7 +61,8 @@ describe "Proxying", ->
         @server.close
 
     describe "Redirection", ->
-        it "When I send non-identified request to an existing private route", (done) ->
+        it "When I send non-identified request to an existing 
+private route", (done) ->
             client.get "apps/myapp/", (error, response, body) =>
                 @response = response
                 done()
@@ -75,7 +76,7 @@ describe "Proxying", ->
     describe "Public proxying", ->
         
         it "When I send a request to an existing public route", (done) ->
-            client.get "apps/myapp/public/", (error, response, body) =>
+            client.get "public/myapp/", (error, response, body) =>
                 @body = body
                 @response = response
                 done()


### PR DESCRIPTION
This PR bypass the proxy authentification for requests under app's /public route, allowing them to expose pages and data to external visitors. 
