### PR TITLE
Improve English locale

### DIFF
--- a/client/locales/en.coffee
+++ b/client/locales/en.coffee
@@ -3,98 +3,98 @@ module.exports =
     # login page
     "login title": "Cozy - Sign in"
     "login headline": "Welcome"
-    "login connection invitation": "Please type your password to sign in:"
+    "login connection invitation": "Please enter your password to sign in:"
     "login password placeholder" : "Your password"
     "login button" : "Sign in"
     "login forget password button" : "Did you forget your password?"
-    "login success message": "Sign in succeeded, let's go to the Cozy Home..."
-    "login reset success message": "An email has been sent to your mailbox, follow its instructions to get a new password."
+    "login success message": "Sign in successful! Let's go to your Cozy Home…"
+    "login reset success message": "An email has been sent to your address, simply follow its instructions to get a new password."
 
     # reset password page
     "reset title": "Cozy - Reset password"
-    "reset headline": "Tell me your new password"
-    "reset instructions": "After a password reset, you must reconfigure your confidential data like your mailbox or your bank account."
+    "reset headline": "Enter your new password"
+    "reset instructions": "After a password reset, you will have to reconfigure confidential data like your mailbox or bank accounts."
     "reset password placeholder": "Your new password"
     "reset button": "Change my password"
-    "reset success message": "Password successfully reset."
+    "reset success message": "Password reset successful."
 
     # register page
     "register title": "Cozy - Sign up"
     "register headline": "Welcome to your Cozy!"
-    "register informations": "It's the first time you connect."
+    "register informations": "This is the first time you're signing in."
     "register instructions": "Before going further, I need:"
-    "register reinsurance modification": "Those information can be modified at any time from the configuration page."
-    "register reinsurance share": "Your Cozy will NEVER share your data without your consent."
+    "register reinsurance modification": "The following information can be modified at any time from the configuration screen."
+    "register reinsurance share": "Your Cozy will NEVER share data without your consent."
     "register button moreinfo": "Enter additional information"
     "register button separator": "or"
-    "register button": "Send informations"
-    "register success message": "Good, let's go to your Cozy homepage."
+    "register button": "Finish registration"
+    "register success message": "Good, now let's go to your Cozy Home."
 
     # register - email field
-    "register email placeholder": "Email (to reset your password)"
-    "register email info": "Your Cozy will use this email address if you lose your password or to send you various information like alerts or daily reports."
-    "register email valid": "The email address is valid."
+    "register email placeholder": "Email (to allow resetting your password)"
+    "register email info": "Your Cozy will use this address to help you if you lose your password, and to send you configurable alerts, daily reports, etc."
+    "register email valid": "This email address is OK."
     "register email invalid": "Enter a valid email address, e.g. john.doe@example.com."
 
     # register - password field
     "register password placeholder": "Pick a new password"
-    "register password info": "Pick a unique password, made of numbers and letters, uppercased and lowercased: it's the shield that keeps your data private!"
-    "register password valid": "Password long enough."
+    "register password info": "Pick a unique password, made of numbers and letters, uppercase and lowercase: it's the shield that keeps your data private!"
+    "register password valid": "Password is long enough."
     "register password invalid": "The password should be at least 5 characters long."
 
     # register -  check password field
     "register check password placeholder": "Enter your password again"
     "register check password info": "Confirm your password."
-    "register check password valid": "Password successfully confirmed."
-    "register check password invalid": "Passwords don't match."
+    "register check password valid": "Password confirmation successful."
+    "register check password invalid": "The passwords don't match."
 
     # register - public name field
-    "register public name placeholder": "Your public name on your Cozy"
+    "register public name placeholder": "Your public name in your Cozy"
     "register public name info": "Your public name will be used by your Cozy and its apps to communicate with you."
 
     # register - timezone field
-    "register timezone info": "The timezone is used by Cozy and its apps to be always on time!"
+    "register timezone info": "The time zone is used by Cozy and its apps to always be on time!"
 
     # error page
     "error title": "Oops, an error has occurred"
     "error headline": "It seems that something went wrong."
-    "error reinsurance": "Don't worry, that's probably not so bad!"
-    "error temporary issue": "It should be a temporary issue, please try again in 5 minutes."
+    "error reinsurance": "Don't worry, it's probably not that bad!"
+    "error temporary issue": "The problem should be temporary, please try again in 5 minutes."
     "error try restart": "If nothing has changed despite that, try to restart your Cozy."
     "error contact cozy team": "If the problem persists, feel free to contact the Cozy team:"
     "error contact forum": 'Ask for help on <a href="https://forum.cozy.io">our forum</a>'
-    "error contact email": "Send an email at contact@cozycloud.cc"
+    "error contact email": "Send an email to contact@cozycloud.cc"
     "error contact irc": "Report the issue on IRC, #cozycloud on irc.freenode.net"
     "error wait a bit": "Wait for 5 minutes"
-    "error restart app": 'Restart the application ("Manage your apps" menu)'
-    "error reinstall app": "Reinstall the application"
+    "error restart app": 'Restart the app ("Manage your apps" menu)'
+    "error reinstall app": "Reinstall the app"
 
     # error page -- not found
-    "error not found info": "You are trying to access an application that is not installed or that is being installed."
+    "error not found info": "You are trying to access an app that is either not installed or currently being installed."
 
     # error page -- error app
-    "error try to fix": "You can try the following to fix it:"
-    "error contact developer": "If nothing has worked, you can contact the application's developer or the Cozy team:"
+    "error try to fix": "You can use the following steps to try and fix the problem:"
+    "error contact developer": "If nothing worked, you can contact the developer of the app or the Cozy team:"
 
     # error page -- public app
-    "error public info": "Please wait for 5 minutes then contact the Cozy owner if nothing has changed!"
+    "error public info": "Please wait for 5 minutes, then contact the Cozy owner if nothing has changed!"
 
     # errors
-    "error server": "Server error occurred."
+    "error server": "An internal error occurred."
     "error bad credentials": "Incorrect password."
-    "error keys not initialized": "Keys aren't initialized."
+    "error keys not initialized": "The keys aren't initialized."
     "error login failed": "Login failed."
 
     # reset password email
-    "reset password email from": "Your Cozy instance <no-reply@%{domain}>"
-    "reset password email subject": "[Cozy] Reset password procedure"
+    "reset password email from": "Your Cozy <no-reply@%{domain}>"
+    "reset password email subject": "[Cozy] Resetting your password"
     "reset password email text": """
-        It seems that you forgot your Cozy's password. No worry about that, just
-        go to the following url and you will be able to set a new one:
+        It seems that you forgot the password to your Cozy.
+        Not to worry, simply follow the link below to create a new one:
 
         https://%{domain}/password/reset/%{key}
 
-        Don't forget to reset all your encrypted data afterwards!
+        Don't forget to update all your encrypted data afterwards!
     """
 
 

--- a/client/locales/fr.coffee
+++ b/client/locales/fr.coffee
@@ -7,7 +7,7 @@ module.exports =
     "login password placeholder" : "Votre mot de passe"
     "login button" : "Se connecter"
     "login forget password button" : "Avez-vous perdu votre mot de passe ?"
-    "login success message": "Connexion réussie, vous allez être redirigé(e) vers l'accueil de votre Cozy..."
+    "login success message": "Connexion réussie ! Vous allez être redirigé(e) vers l'accueil de votre Cozy…"
     "login reset success message": "Un email a été envoyé à votre adresse, suivez les instructions de ce dernier pour réinitialiser votre mot de passe."
 
     # reset password page
@@ -88,7 +88,7 @@ module.exports =
 
     # reset password email
     "reset password email from": "Votre Cozy <no-reply@%{domain}>"
-    "reset password email subject": "[Cozy] Procédure de réinitialisation du mot de passe"
+    "reset password email subject": "[Cozy] Réinitialiser votre mot de passe"
     "reset password email text": """
         Il semble que vous ayez oublié le mot de passe de votre Cozy.
         Ne vous inquiétez pas, suivez simplement le lien suivant pour en définir un nouveau :


### PR DESCRIPTION
This locale was already pretty good, but I couln't resist tweaking it some more!

My main problem was with "Send informations", which is incorrect (information is already plural) and misleading / scary: As a new user, I wondered "Where is my private information being sent to? Isn't the point of Cozy to not send information to the cloud?" Etc. I originally wanted to replace it with "Save", but "Finish registration" is closer to the French locale.