### PR TITLE
Help browser handle password field and automatically remember the password

### DIFF
--- a/client/app/login.coffee
+++ b/client/app/login.coffee
@@ -6,6 +6,9 @@ $ ->
     errorAlert = $ '.alert-error'
     successAlert = $ '.alert-success'
     forgotPassword = $ '#forgot-password'
+    $('#proxy-form').submit (e) ->
+        e.preventDefault()
+        false
     submitPassword = ->
         button.spin 'small'
         loader.spin 'small'

--- a/server/views/login.jade
+++ b/server/views/login.jade
@@ -11,7 +11,7 @@ block js
         var LOGIN_BUTTON_LABEL = "#{polyglot.t('login button')}";
 
 block content
-    .proxy-form
+    form.proxy-form#proxy-form
         h1
             | #{polyglot.t('login headline')}&nbsp;
             span#username= name


### PR DESCRIPTION
So that's everything which is needed to make sure the password field is automatically detected by the browser as a password field it can remember, and autocomplete in the future:
- wrap the input type=password inside a form
- reverse effects of submitting the form