### PR TITLE
[NEED DISCUSSION] Specify a max-age for static assets 

### DIFF
--- a/server/config.coffee
+++ b/server/config.coffee
@@ -33,7 +33,9 @@ config =
             americano.errorHandler
                 dumpExceptions: true
                 showStack: true
-            americano.static path.join __dirname, '/../client/public'
+            americano.static path.join __dirname, '/../client/public',
+                maxAge: 5 * 60 * 1000
+
             selectiveBodyParser
             usetracker
             authSteps[0]


### PR DESCRIPTION
There is a tradeof here : 

By default, the max-age is 0 and the proxy assets can never be totally cached. 

In emails, we create an iframe with a link to the /fonts/fonts.css every time a message is displayed, this cause the browser to make 3 requests (fonts.css & 2*.woff) and recompute fonts even if it receive 304 responses.
  
However, the usage of high max ages is most probably the cause of our cache problems (forcing users to ctrl + F5 after an update).

For now, i think i will stop cozy-emails from using the proxy "cdn" as the use case of creating iframes is very specific.

Let's make this the discussion about the cache problem and how best to solve it not only for proxy but for all our apps.
Pinging @m4dz @clochix @frankrousseau @jsilvestre 

