### PR TITLE
Improve travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ services:
 cache:
     directories:
         - node_modules
+addons:
+    apt:
+        packages:
+            - netstat
 
 before_install:
     - git clone git://github.com/cozy/cozy-data-system.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
+sudo: false
 language: node_js
 matrix:
     fast_finish: true
     allow_failures:
-        - node_js: "0.12"
+        - node_js: 4
 branches:
   except:
     - demo
 node_js:
-    - "0.10"
-    - "0.12"
-services:
-    - couchdb
+    - 0.10
+    - 0.12
+    - 4
 env:
     global:
         - NODE_ENV=test
+services:
+    - couchdb
+cache:
+    directories:
+        - node_modules
+
 before_install:
     - git clone git://github.com/cozy/cozy-data-system.git
     - cd cozy-data-system
@@ -23,9 +29,16 @@ before_install:
     - NAME=data-system TOKEN=token forever start -o forever-ds.log build/server.js
     - ps aux | grep server.js
     - sleep 5
-    - cat forever-ds.log
-    - sudo netstat -plunt
     - curl http://localhost:9101/
     - cd ..
     - export NAME=proxy
     - export TOKEN=token
+
+after_failure:
+    - pwd
+    - ps aux | grep server.js
+    - netstat -lntp
+    - cat ~/cozy-data-system/forever-ds.log
+    - cat ~/cozy-proxy/forever-proxy.log
+    - curl http://localhost:9101/
+    - curl http://localhost:9104/

--- a/Cakefile
+++ b/Cakefile
@@ -54,7 +54,6 @@ task 'tests', "Run tests #{taskDetails}", (opts) ->
         console.log stdout
         console.log stderr
         if err
-            err = err
             logger.error "Running mocha caught exception:\n" + err
             process.exit 1
         else

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Each modification requires a new build, here is how to run a build:
 
 ![Build Status](https://travis-ci.org/cozy/cozy-proxy.png?branch=master)
 
-To run tests type the following command into the Cozy Home folder:
+To run tests, type the following command into the Cozy Proxy folder:
 
     cake tests
+
+Note: a running data-system is required for the tests.
 
 ## Icons
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "americano": "0.3.7",
     "americano-cozy": "0.2.6",
     "async": "0.2.10",
-    "bcrypt": "0.8.1",
+    "bcrypt": "0.8.5",
     "cookie-parser": "1.3.2",
     "cookie-session": "1.0.2",
     "graceful-fs": "^3.0.2",

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -15,6 +15,8 @@ helpers.options =
     serverHost: process.env.HOST or 'localhost'
     serverPort: process.env.PORT or 9104
 
+localization = require "#{helpers.prefix}server/lib/localization_manager"
+
 # default client
 client = new Client "http://#{helpers.options.serverHost}:#{helpers.options.serverPort}/", jar: true
 
@@ -139,3 +141,6 @@ helpers.closeFakeServers = ->
     for name, server of @fakeServers
         server.close()
     @fakeServers = {}
+
+helpers.setDefaultLocale = ->
+    localization.setLocale 'en'

--- a/test/models_test.coffee
+++ b/test/models_test.coffee
@@ -4,6 +4,7 @@ User = require "#{helpers.prefix}server/models/user"
 
 describe "Models", ->
 
+    before helpers.setDefaultLocale
     before helpers.createAllRequests
     before helpers.deleteAllUsers
     after  helpers.deleteAllUsers


### PR DESCRIPTION
- Faster travis build, by using [the new infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) and cache for npm modules
- use `after_failure` for debug
- Force the locale for tests that depends of it
- Update bcrypt for node 4