### PR TITLE
Revert the upgrade of bcrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "americano": "0.3.7",
     "americano-cozy": "0.2.6",
     "async": "0.2.10",
-    "bcrypt": "0.8.5",
+    "bcrypt": "0.8.1",
     "cookie-parser": "1.3.2",
     "cookie-session": "1.0.2",
     "graceful-fs": "^3.0.2",


### PR DESCRIPTION
The install of bcrypt 0.8.5 fails with the default npm on debian jessie.