### PR TITLE
Use http code 204, better for a deleted content

### DIFF
--- a/server/controllers/devices.coffee
+++ b/server/controllers/devices.coffee
@@ -255,7 +255,7 @@ module.exports.remove = (req, res, next) ->
                     if err?
                         next err
                     else
-                        res.send 200
+                        res.send 204
 
     initAuth req, (user) ->
         # Check if request is authenticated


### PR DESCRIPTION
Hi,

I think it should be better to send a 204 No Content when a device is deleted. It matches more elegantly the HTTP semantics and it avoids to send `OK`, which is a not valid JSON payload.

![204 No Content](http://httpstatusdogs.com/wp-content/uploads/2011/12/2041.jpg)