### PR TITLE
Correct urlencode ? for redirection from login when user isn t auth. …

### DIFF
--- a/server/middlewares/authentication.coffee
+++ b/server/middlewares/authentication.coffee
@@ -33,6 +33,6 @@ module.exports.isAuthenticated = (req, res, next) ->
         next()
     else
         url = "/login"
-        url += "?next=#{req.url}" unless req.url is '/'
+        url += "?next=#{req.url.replace "?", "%3F"}" unless req.url is '/'
         url += "&#{qs.stringify req.query}" if req.query.length
         res.redirect url

--- a/server/middlewares/authentication.coffee
+++ b/server/middlewares/authentication.coffee
@@ -33,6 +33,6 @@ module.exports.isAuthenticated = (req, res, next) ->
         next()
     else
         url = "/login"
-        url += "?next=#{req.url.replace "?", "%3F"}" unless req.url is '/'
+        url += "?next=#{encodeURIComponent req.url}" unless req.url is '/'
         url += "&#{qs.stringify req.query}" if req.query.length
         res.redirect url


### PR DESCRIPTION
Fix issue #215

When user is not logged, the redirection to /login for authorizing remotestorage connection redirect to /login?next=/apps/remotestorage/oauth/?redirect_uri=http://litewrite.net/&scope=documents:rw&client_id=http://litewrite.net&response_type=token

the second ? should be urlencoded else the parameter of next= aren t present after login on the next redirection.