### PR TITLE
Add a missing error handler

### DIFF
--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -80,10 +80,13 @@ module.exports.register = (req, res, next) ->
         next error
 
 
-module.exports.loginIndex = (req, res) ->
+module.exports.loginIndex = (req, res, next) ->
     getEnv (err, env) ->
-        return res.redirect '/register' unless env.username
-        res.render 'index', env: env
+        if err
+            next new Error err
+        else
+            return res.redirect '/register' unless env.username
+            res.render 'index', env: env
 
 
 module.exports.forgotPassword = (req, res, next) ->
@@ -110,10 +113,13 @@ module.exports.forgotPassword = (req, res, next) ->
 
 module.exports.resetPasswordIndex = (req, res) ->
     getEnv (err, env) ->
-        if Instance.getResetKey() is req.params.key
-            res.render 'index', env: env
+        if err
+            next new Error err
         else
-            res.redirect '/'
+            if Instance.getResetKey() is req.params.key
+                res.render 'index', env: env
+            else
+                res.redirect '/'
 
 
 module.exports.resetPassword = (req, res, next) ->

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -111,7 +111,7 @@ module.exports.forgotPassword = (req, res, next) ->
                     res.send 204
 
 
-module.exports.resetPasswordIndex = (req, res) ->
+module.exports.resetPasswordIndex = (req, res, next) ->
     getEnv (err, env) ->
         if err
             next new Error err


### PR DESCRIPTION
This should fix an exception saw in error logs:
```
Cannot read property 'username' of undefined
TypeError: Cannot read property 'username' of undefined
    at /usr/local/cozy/apps/proxy/build/server/controllers/authentication.js:110:13
    at /usr/local/cozy/apps/proxy/build/server/controllers/authentication.js:26:14
    at /usr/local/cozy/apps/proxy/build/server/models/user.js:77:14
    at /usr/local/cozy/apps/proxy/build/server/models/user.js:64:14
    at /usr/local/cozy/apps/proxy/node_modules/americano-cozy/node_modules/jugglingdb-cozy-adapter/lib/cozy_data_system.js:405:18
    at parseBody (/usr/local/cozy/apps/proxy/node_modules/americano-cozy/node_modules/jugglingdb-cozy-adapter/node_modules/request-json/main.js:26:12)
    at Request._callback (/usr/local/cozy/apps/proxy/node_modules/americano-cozy/node_modules/jugglingdb-cozy-adapter/node_modules/request-json/main.js:81:18)
    at Request.self.callback (/usr/local/cozy/apps/proxy/node_modules/americano-cozy/node_modules/jugglingdb-cozy-adapter/node_modules/request-json/node_modules/request/index.js:148:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/usr/local/cozy/apps/proxy/node_modules/americano-cozy/node_modules/jugglingdb-cozy-adapter/node_modules/request-json/node_modules/request/index.js:876:14)

```