### PR TITLE
Add a postinstall script for node4 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   "scripts": {
     "test": "cake --use-js tests",
     "start": "node build/server.js",
-	"postinstall": "node postinstall.js"
+    "postinstall": "node postinstall.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "americano": "0.3.7",
     "americano-cozy": "0.2.6",
     "async": "0.2.10",
-    "bcrypt": "0.8.1",
     "cookie-parser": "1.3.2",
     "cookie-session": "1.0.2",
     "graceful-fs": "^3.0.2",
@@ -51,6 +50,7 @@
   "main": "server.js",
   "scripts": {
     "test": "cake --use-js tests",
-    "start": "node build/server.js"
+    "start": "node build/server.js",
+	"postinstall": "node postinstall.js"
   }
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var spawn = require('child_process').spawn;
+var major = process.versions.node.split('.')[0];
+var bcrypt = 'bcrypt@0.8.5';
+
+if (major == '0') {
+  bcrypt = 'bcrypt@0.8.1';
+}
+spawn('npm', ['install', bcrypt], { stdio: 'inherit' });

--- a/postinstall.js
+++ b/postinstall.js
@@ -4,7 +4,7 @@ var spawn = require('child_process').spawn;
 var major = process.versions.node.split('.')[0];
 var bcrypt = 'bcrypt@0.8.5';
 
-if (major == '0') {
+if (major === '0') {
   bcrypt = 'bcrypt@0.8.1';
 }
 spawn('npm', ['install', bcrypt], { stdio: 'inherit' });


### PR DESCRIPTION
Bcrypt@0.8.1 is compatible with node 0.x.y
Bcrypt@0.8.5 is compatible with node 0.10.40+

We want cozy-proxy to works on:

- node 0.10.25 (the version installed by default on ubuntu)
- node 0.10.29 (the version installed by default on debian)
- the current stable release of node 0.10, 0.12, 4 and 5

So, we have to use the postinstall feature of npm to check the version
of node and install a version of bcrypt compatible with it.