### PR TITLE
Preserve encrypted data when reseting password, if possible

### DIFF
--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -147,7 +147,7 @@ module.exports.resetPassword = (req, res, next) ->
                         if err? then next new Error err
                         else
                             Instance.resetKey = null
-                            passwordKeys.resetKeys (err) ->
+                            passwordKeys.resetKeys newPassword, (err) ->
 
                                 if err? then next new Error err
                                 else

--- a/server/lib/password_keys.coffee
+++ b/server/lib/password_keys.coffee
@@ -3,38 +3,25 @@ Client = require("request-json").JsonClient
 
 class PasswordKeys
 
-
     constructor: ->
         @client = new Client "http://localhost:9101/"
         @name = process.env.NAME
         @token = process.env.TOKEN
-        nodeEnv = process.env.NODE_ENV
-        if nodeEnv is "production" or nodeEnv is "test"
+        if process.env.NODE_ENV in ["production", "test"]
             @client.setBasicAuth @name, @token
 
-
     initializeKeys: (pwd, callback) ->
-        @client.post "accounts/password/", password: pwd, (err, res, body) ->
-            if err
-                callback err
-            else
-                callback()
-
+        @client.post "accounts/password/", password: pwd, callback
 
     updateKeys: (pwd, callback) ->
-        @client.put "accounts/password/", password: pwd, (err, res, body) ->
-            if err
-                callback err
-            else
-                callback()
+        @client.put "accounts/password/", password: pwd, callback
 
-
-    resetKeys: (callback) ->
-        @client.del "accounts/reset/", (err, res, body) ->
-            if err
-                callback err
+    resetKeys: (pwd, callback) ->
+        @client.put "accounts/password/", password: pwd, (err, res, body) =>
+            if res?.statusCode is 400
+                @client.del "accounts/reset/", callback
             else
-                callback()
+                callback err
 
 
 module.exports = new PasswordKeys()


### PR DESCRIPTION
When the user reset its password, we try to preserve its `slaveKey` in the data-system that encrypts/decrypts the passwords saved in CouchDB. It's possible if the user has already logged in since the last restart of the data-system, as `slaveKey` is kept in memory.