### PR TITLE
Continue #246

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ We assume here that the Cozy platform is correctly [installed](https://raw.githu
 
 Type this command to install the proxy module:
 
-    cozy-monitor install proxy
+```sh
+$ cozy-monitor install proxy
+```
 
 ## Contribution
 
@@ -41,14 +43,14 @@ documentation](https://docs.cozy.io/en/hack/cookbooks/controller.html#configurat
 Just add the following lines into this file:
 
 ```json
-    "env": {
-      "proxy": {
-        "PORT": 443,
-        "USE_SSL": true,
-        "SSL_CRT_PATH": "/path/to/server.crt",
-        "SSL_KEY_PATH": "/path/to/server.key"
-      }
-    }
+"env": {
+  "proxy": {
+    "PORT": 443,
+    "USE_SSL": true,
+    "SSL_CRT_PATH": "/path/to/server.crt",
+    "SSL_KEY_PATH": "/path/to/server.key"
+  }
+}
 ```
 
 ## Hack
@@ -57,25 +59,19 @@ To be hacked, the Cozy Proxy dev environment requires that a CouchDB instance
 and a Cozy Data System instance are running. Then you can start the Cozy Proxy
 this way:
 
-    git clone https://github.com/cozy/cozy-proxy.git
-    cd cozy-proxy
-    npm install -g brunch coffee-script coffeelint
-    npm install
-    cd client
-    npm install
-    cd ..
-    coffee server.coffee
-
-Each modification requires a new build, here is how to run a build:
-
-    npm run build
+```sh
+$ git clone https://github.com/cozy/cozy-proxy.git
+$ cd cozy-proxy
+$ npm install
+$ npm run watch
+```
 
 ### To hack cozy-proxy using the cozy vagrant
 
 - Forward a new port from the virtual machine (for example: `config.vm.network :forwarded_port, guest: 9555, host: 9555` in file Vagrantfile)
 - Go in the shared folder `cd /vagrant` and `cd your-cozy-proxy-folder`
 - `rm -rf node_modules/bcrypt && npm install`
-- Launch cozy-proxy `PORT=9555 HOST="0.0.0.0" coffee server.coffee`
+- Launch cozy-proxy `PORT=9555 HOST="0.0.0.0" npm run watch`
 - You can now access the hacked proxy on `http://localhost:9555` with your navigator
 
 ## Tests
@@ -84,7 +80,9 @@ Each modification requires a new build, here is how to run a build:
 
 To run tests, type the following command into the Cozy Proxy folder:
 
-    npm run test
+```sh
+$ npm run test
+```
 
 Note: a running data-system is required for the tests.
 

--- a/client/README.md
+++ b/client/README.md
@@ -7,22 +7,20 @@ This frontend application serves the cozy-proxy browser app. It relies on the se
 - onboarding (all its subscreens)
 
 
-## Requirements
+## Development
 
-You need a valid node.js/npm environment to develop the app. We use [Brunch](http://brunch.io/) as build tool, so you want it installed on your system:
-
-```sh
-$ npm -g i brunch
-```
-
-Before trying to develop the front app, you need to load its dependencies:
+*TL;DR*:
 
 ```sh
-npm i
-./node_modules/.bin/bower install
+# in your top-level cozy-proxy directory
+$ npm run watch
 ```
 
-_NOTE:_ we currently use Bower as deps manager to avoid deps in the app repository. We'll replace it by npm node_modules packages when Brunch will be stable enough to use it for the vendor files.
+Then point your browser to http://localhost:3000.
+
+***
+
+We use [Webpack](https://webpack.github.io/docs/) as build tool, and every dependencies are loaded _via_ NPM. All development tasks are loaded through NPM scripts at the project top-level, so you should launch the development watcher from the `cozy-proxy` directory by running `npm run watch`. It'll load the server part in watch mode, the webpack builder in watch mode too, and proxify the server behind [BrowserSync](https://browsersync.io/) for hot-reloading. BrowserSync exposes at [localhost:3000](http://localhost:3000) by default.
 
 
 ## Librairies
@@ -40,7 +38,7 @@ This front-end app have inline code documentation, so you can read it as well as
 The app is organized in the following way:
 
 ```txt
-app/
+- app/
   |- initialize.coffee       # sets the browser environment and launch app
   |- application.coffee      # Backbone.Marionette application singleton instance
   |
@@ -67,7 +65,10 @@ app/
   |  |- base                 # the shared rules framework
   |  `- components           # specific app stylesheets, organized per component
   |
-  `- assets                  # frontend assets copied directly by Brunch
+  `- assets                  # frontend assets referenced in modules
+
+- vendor
+  `- assets                  # frontend assets directly copied to build
   ```
 
 ### App workflow

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -7,13 +7,13 @@ var CopyPlugin        = require('copy-webpack-plugin');
 var AssetsPlugin      = require('assets-webpack-plugin');
 var BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
-var production = process.env.NODE_ENV === 'production';
+var optimize = process.env.OPTIMIZE === 'true';
 
 var autoprefixer = require('autoprefixer')(['last 2 versions']);
 var mqpacker     = require('css-mqpacker');
 
 var plugins = [
-    new ExtractTextPlugin(production? 'app.[hash].css' : 'app.css'),
+    new ExtractTextPlugin(optimize? 'app.[hash].css' : 'app.css'),
     new webpack.optimize.CommonsChunkPlugin({
         name:      'main',
         children:  true,
@@ -24,7 +24,7 @@ var plugins = [
     ])
 ];
 
-if (production) {
+if (optimize) {
     plugins = plugins.concat([
         new AssetsPlugin({
             filename: '../build/webpack-assets.json'
@@ -38,9 +38,9 @@ if (production) {
             },
         }),
         new webpack.DefinePlugin({
-            __SERVER__:      !production,
-            __DEVELOPMENT__: !production,
-            __DEVTOOLS__:    !production
+            __SERVER__:      !optimize,
+            __DEVELOPMENT__: !optimize,
+            __DEVTOOLS__:    !optimize
         })
     ]);
 } else {
@@ -55,15 +55,15 @@ if (production) {
 module.exports = {
     entry: './app/initialize',
     output: {
-        path: path.join(production? '../build/client' : '', 'public'),
-        filename: production? 'app.[hash].js' : 'app.js',
-        chunkFilename: production? 'register.[hash].js' : 'register.js'
+        path: path.join(optimize? '../build/client' : '', 'public'),
+        filename: optimize? 'app.[hash].js' : 'app.js',
+        chunkFilename: optimize? 'register.[hash].js' : 'register.js'
     },
     resolve: {
         extensions: ['', '.js', '.coffee', '.jade', '.json']
     },
-    debug: !production,
-    devtool: production ? false : 'eval',
+    debug: !optimize,
+    devtool: 'source-map',
     module: {
         loaders: [
             {
@@ -72,12 +72,12 @@ module.exports = {
             },
             {
                 test: /\.styl$/,
-                loader: ExtractTextPlugin.extract('style', production? 'css?-svgo&-autoprefixer&-mergeRules!postcss!stylus' : 'css!stylus')
+                loader: ExtractTextPlugin.extract('style', optimize? 'css?-svgo&-autoprefixer&-mergeRules!postcss!stylus' : 'css!stylus')
             },
             {
                 test: /\.css$/,
                 exclude: /vendor/,
-                loader: ExtractTextPlugin.extract('style', production? 'css?-svgo&-autoprefixer&-mergeRules!postcss' : 'css')
+                loader: ExtractTextPlugin.extract('style', optimize? 'css?-svgo&-autoprefixer&-mergeRules!postcss' : 'css')
             },
             {
                 test: /\.jade$/,
@@ -90,7 +90,7 @@ module.exports = {
             {
                 test: /\.(png|gif|jpe?g|svg)$/i,
                 exclude: /vendor/,
-                loader:  'file?name=img/' + (production? '[name].[hash].[ext]' : '[name].[ext]')
+                loader:  'file?name=img/' + (optimize? '[name].[hash].[ext]' : '[name].[ext]')
             }
         ]
     },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,17 +1,73 @@
 var path = require('path');
 
-var webpack           = require('webpack');
+var webpack = require('webpack');
 
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyPlugin        = require('copy-webpack-plugin');
 var AssetsPlugin      = require('assets-webpack-plugin');
 var BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
+// use the `OPTIMIZE` env VAR to switch from dev to production build
 var optimize = process.env.OPTIMIZE === 'true';
 
-var autoprefixer = require('autoprefixer')(['last 2 versions']);
-var mqpacker     = require('css-mqpacker');
+/**
+ * Loaders used by webpack
+ *
+ * - CSS and images files from `vendor` are excluded
+ * - stylesheets are optimized via cssnano, minus svgo and autoprefixer that are
+ * customized via PostCSS
+ * - images are cache-busted in production build
+ */
+var cssOptions = optimize? 'css?-svgo&-autoprefixer&-mergeRules!postcss':'css';
+var imgPath = 'img/' + '[name]' + (optimize? '.[hash]': '') + '.[ext]';
+var loaders = [
+    {
+        test: /\.coffee$/,
+        loader: 'coffee'
+    },
+    {
+        test: /\.styl$/,
+        loader: ExtractTextPlugin.extract('style', cssOptions + '!stylus')
+    },
+    {
+        test: /\.css$/,
+        exclude: /vendor/,
+        loader: ExtractTextPlugin.extract('style', cssOptions)
+    },
+    {
+        test: /\.jade$/,
+        loader: 'jade'
+    },
+    {
+        test: /\.json$/,
+        loader: 'json'
+    },
+    {
+        test: /\.(png|gif|jpe?g|svg)$/i,
+        exclude: /vendor/,
+        loader: 'file?name=' + imgPath
+    }
+];
 
+/**
+ * Configure Webpack's plugins to tweaks outputs:
+ *
+ * all builds:
+ * - ExtractTextPlugin: output CSS to file instead of inlining it
+ * - CommonsChunkPlugin: push to _main_ file the common dependencies
+ * - CopyPlugin: copy assets to public dir
+ *
+ * prod build:
+ * - AssetsPlugin: paths to cache-busted's assets to read them from server
+ * - DedupePlugin
+ * - OccurenceOrderPlugin
+ * - UglifyJsPlugin
+ * - DefinePlugin: disable webpack env dev vars
+ *
+ * dev build:
+ * - BrowserSyncPlugin: make hot reload via browsersync exposed at
+ *   http://localhost:3000, proxified to the server app port
+ */
 var plugins = [
     new ExtractTextPlugin(optimize? 'app.[hash].css' : 'app.css'),
     new webpack.optimize.CommonsChunkPlugin({
@@ -32,7 +88,7 @@ if (optimize) {
         new webpack.optimize.DedupePlugin(),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.optimize.UglifyJsPlugin({
-            mangle:   true,
+            mangle: true,
             compress: {
                 warnings: false
             },
@@ -52,6 +108,24 @@ if (optimize) {
     ]);
 }
 
+/**
+ * PostCSS Config
+ *
+ * - autoprefixer to add vendor prefixes for last 2 versions
+ * - mqpacker to bring together all MQ rule's set
+ */
+var postcss = [
+    require('autoprefixer')(['last 2 versions']),
+    require('css-mqpacker')
+];
+
+/**
+ * Webpack config
+ *
+ * - output to `public` dir
+ * - cache-bust assets when build for production
+ */
+
 module.exports = {
     entry: './app/initialize',
     output: {
@@ -65,35 +139,8 @@ module.exports = {
     debug: !optimize,
     devtool: 'source-map',
     module: {
-        loaders: [
-            {
-                test: /\.coffee$/,
-                loader: 'coffee'
-            },
-            {
-                test: /\.styl$/,
-                loader: ExtractTextPlugin.extract('style', optimize? 'css?-svgo&-autoprefixer&-mergeRules!postcss!stylus' : 'css!stylus')
-            },
-            {
-                test: /\.css$/,
-                exclude: /vendor/,
-                loader: ExtractTextPlugin.extract('style', optimize? 'css?-svgo&-autoprefixer&-mergeRules!postcss' : 'css')
-            },
-            {
-                test: /\.jade$/,
-                loader: 'jade'
-            },
-            {
-                test: /\.json$/,
-                loader: 'json'
-            },
-            {
-                test: /\.(png|gif|jpe?g|svg)$/i,
-                exclude: /vendor/,
-                loader:  'file?name=img/' + (optimize? '[name].[hash].[ext]' : '[name].[ext]')
-            }
-        ]
+        loaders: loaders
     },
     plugins: plugins,
-    postcss: [autoprefixer, mqpacker]
+    postcss: postcss
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "build": "npm-run-all --parallel 'build:*'",
     "build:server": "coffee -cb --output build/server server && coffee -cb --output build/ server.coffee",
-    "build:client": "cd client && env NODE_ENV=production webpack",
+    "build:client": "cd client && env OPTIMIZE=true webpack",
     "build:views": "jade2commonjs --no-debug --out build/server/views --ignore '**/_*.jade' server/views",
     "clean": "rm -rf build",
     "copy:locales": "mkdir -p build/server/locales && cp -r server/locales/*.json build/server/locales/",

--- a/server/initialize.coffee
+++ b/server/initialize.coffee
@@ -23,6 +23,10 @@ module.exports = (app, server, callback) ->
     # watch mode)
     try
         assets = require(path.join __dirname, '../webpack-assets').main
+    catch
+        assets =
+            js: 'app.js'
+            css: 'app.css'
     app.locals.assets = assets
 
     # initialize Proxy server

--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -19,4 +19,4 @@ block js
     if env
         script.
             ENV = !{JSON.stringify(env)};
-    script(src="/#{assets? assets.js : 'app.js'}" defer=true)
+    script(src="/#{assets.js}" defer=true)

--- a/server/views/layouts/_base.jade
+++ b/server/views/layouts/_base.jade
@@ -27,7 +27,7 @@ html(lang=getLocale())
         meta(name="theme-color", content="#20a8f1")
 
         link(rel="stylesheet", href="/fonts/fonts.css")
-        link(rel="stylesheet", href="/#{assets? assets.css : 'app.css'}")
+        link(rel="stylesheet", href="/#{assets.css}")
 
         block js
 


### PR DESCRIPTION
This PR continue #246 by:
- fix README doc
- use env `OPTIMIZE=true` instead of `NODE_ENV=production` to switch to production build
- enable sourcemaps everywhere
- explicitely define assets in dev mode
- improve webpack config for readability and doc