### PR TITLE
Fix locales support

### DIFF
--- a/server/config.coffee
+++ b/server/config.coffee
@@ -24,10 +24,13 @@ authSteps = [
 
 useBuildView = fs.existsSync path.resolve(__dirname, 'views/index.js')
 
+locales = fs.readdirSync(path.join(__dirname, 'locales')).map (file) ->
+    path.basename file, '.json'
+
 
 config =
     authSteps: authSteps
-    supportedLanguages: ['en', 'fr']
+    supportedLanguages: locales
     common:
         use: [
             americano.errorHandler

--- a/server/lib/localization_manager.coffee
+++ b/server/lib/localization_manager.coffee
@@ -10,7 +10,6 @@ supported            = new Locale.Locales supportedLanguages
 class LocalizationManager
     # Polyglot instance in the given locale
     polyglot: null
-    defaultPolyglot: null
 
     constructor: ->
         Instance.getLocale (err, locale) =>
@@ -22,7 +21,7 @@ class LocalizationManager
         # Early return if locale is already the loaded one
         return if @polyglot?.locale is locale
 
-        # Trying to find and use the best locale available
+        # Trying to find and use the best locale available in config
         locales = new Locale.Locales locale
         @setPolyglot locales.best supported
 
@@ -37,9 +36,6 @@ class LocalizationManager
             phrases = require '../locales/en'
 
         @polyglot = new Polyglot locale: locale, phrases: phrases
-        @defaultPolyglot = new Polyglot
-            locale: 'en'
-            phrases: require('../locales/en')
         return @polyglot
 
 
@@ -51,9 +47,10 @@ class LocalizationManager
     # Expose Polyglot interns (i.e. for templating)
     # Those functions ensure polyglot is properly loaded before returning
     # content.
-    getLocale:            => return @getPolyglot()?.locale()
+    getLocale: =>
+        return @getPolyglot()?.locale()
+
     t: (key, params = {}) =>
-        params._ ?= @defaultPolyglot?.t key, params
         return @getPolyglot()?.t key, params
 
 

--- a/server/views/layouts/_base.jade
+++ b/server/views/layouts/_base.jade
@@ -1,5 +1,5 @@
 doctype html
-html(lang=getLocale())
+html(lang=getLocale().language)
     head
         meta(charset="utf-8")
         block title


### PR DESCRIPTION
This PR:
- Remove the unneeded `defaultPolyglot` instance in localization manager (Transifex serves untranslated string by default, non need to do it manually)
- compute the list of available fonts directly for the _locales_ dir
- fix the returned `lang` attribute that was corrupted