### PR TITLE
Rename OTP field name

### DIFF
--- a/server/lib/passport_configurator.coffee
+++ b/server/lib/passport_configurator.coffee
@@ -47,7 +47,7 @@ module.exports = ->
             if err?
                 done err
             else
-                done null, user.otpKey, user.hotpCounter
+                done null, user.encryptedOtpKey, user.hotpCounter
     , (user, key, counter, delta, done) ->
         User.first (err, user) ->
             if err?
@@ -55,7 +55,7 @@ module.exports = ->
             else
                 if counter > user.hotpCounter
                     User.updateAttributes user._id,
-                        otpKey: key
+                        encryptedOtpKey: key
                         hotpCounter: counter
                     , (err) ->
                         done err
@@ -69,4 +69,4 @@ module.exports = ->
             if err?
                 done err
             else
-                done null, user.otpKey, 30
+                done null, user.encryptedOtpKey, 30

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -21,7 +21,7 @@ module.exports = User = cozydb.getModel 'User',
     owner: Boolean
     allow_stats: Boolean
     activated: Boolean
-    otpKey: String
+    encryptedOtpKey: String
     hotpCounter: Number
     authType: String
 

--- a/test/passport_test.coffee
+++ b/test/passport_test.coffee
@@ -21,7 +21,7 @@ hotpToken = "348470"
 
 User = cozydb.getModel 'User',
     authType: String,
-    otpKey: String
+    encryptedOtpKey: String
     hotpCounter: Number
 
 
@@ -75,7 +75,7 @@ describe "Register / Login", ->
                 User.request "all", (error, users) ->
                     users[0].updateAttributes
                         authType: "totp",
-                        otpKey: otpKey
+                        encryptedOtpKey: otpKey
                     , (error) ->
                         done()
 


### PR DESCRIPTION
Rename the field for OTP key in the User doctype in order to have it encrypted in the DataSystem, following https://github.com/cozy/cozy-data-system/pull/226

To merge only the PR linked above is merged, so if the pattern for encrypted fields changes during the review, I'll be able to change it here without opening another PR.