### PR TITLE
Fix server-less apps authentication

### DIFF
--- a/server/controllers/devices.coffee
+++ b/server/controllers/devices.coffee
@@ -257,7 +257,7 @@ module.exports.remove = (req, res, next) ->
                     res.sendStatus 204
 
     if deviceName is username
-        remoteAccess.isDeviceAuthenticated authHeader, (auth) ->
+        remoteAccess.isAuthenticated authHeader, (auth) ->
             if auth
                 remove()
             else
@@ -284,7 +284,7 @@ module.exports.remove = (req, res, next) ->
 
 module.exports.replication = (req, res, next) ->
     # Authenticate the request
-    remoteAccess.isDeviceAuthenticated req.headers['authorization'], (auth) ->
+    remoteAccess.isAuthenticated req.headers['authorization'], (auth) ->
         if auth
             # Forward request for DS.
             getProxy().web req, res, target: urlHelper.dataSystem.url()
@@ -297,7 +297,7 @@ module.exports.replication = (req, res, next) ->
 module.exports.dsApi = (req, res, next) ->
     # Authenticate the request
     authHeader = req.headers['authorization'] or req.query.authorization
-    remoteAccess.isDeviceAuthenticated authHeader, (auth) ->
+    remoteAccess.isAuthenticated authHeader, (auth) ->
         if auth
             # Forward request for DS.
             req.url = req.url.replace 'ds-api/', ''
@@ -310,7 +310,7 @@ module.exports.dsApi = (req, res, next) ->
 
 module.exports.getVersions = (req, res, next) ->
     # Authenticate the request
-    remoteAccess.isDeviceAuthenticated req.headers['authorization'], (auth) ->
+    remoteAccess.isAuthenticated req.headers['authorization'], (auth) ->
         if auth
             # Forward request for DS.
             appManager.versions (err, apps) ->
@@ -331,7 +331,7 @@ module.exports.getVersions = (req, res, next) ->
 module.exports.oldReplication = (req, res, next) ->
 
     # Authenticate the request
-    remoteAccess.isDeviceAuthenticated req.headers['authorization'], (auth) ->
+    remoteAccess.isAuthenticated req.headers['authorization'], (auth) ->
         if auth
             # Add his creadentials for CouchDB
             if process.env.NODE_ENV is "production"

--- a/server/controllers/disk.coffee
+++ b/server/controllers/disk.coffee
@@ -41,7 +41,7 @@ getAuthController = ->
 
 module.exports.getSpace = (req, res, next) ->
     # Authenticate the device
-    remoteAccess.isDeviceAuthenticated req.headers['authorization'], (auth) ->
+    remoteAccess.isAuthenticated req.headers['authorization'], (auth) ->
         if auth
             # Recover disk space with controller
             controllerClient.setToken getAuthController()

--- a/server/controllers/sharing.coffee
+++ b/server/controllers/sharing.coffee
@@ -123,7 +123,7 @@ module.exports.revoke = (req, res, next) ->
 
     authHeader = req.headers['authorization']
     # Authenticate the request
-    remoteAccess.isSharingAuthenticated authHeader, (auth) ->
+    remoteAccess.isAuthenticated authHeader, (auth) ->
         if auth
             # Extract the shareID
             [shareID, token] = remoteAccess.extractCredentials authHeader
@@ -219,7 +219,7 @@ module.exports.answer = (req, res, next) ->
 # Forward the replication to the DS if the request is authenticated
 module.exports.replication = (req, res, next) ->
     # Authenticate the request
-    remoteAccess.isSharingAuthenticated req.headers['authorization'], (auth) ->
+    remoteAccess.isAuthenticated req.headers['authorization'], (auth) ->
         if auth
             # Forward request for DS.
             req.url = req.url.replace 'services/sharing/', ''

--- a/server/initialize.coffee
+++ b/server/initialize.coffee
@@ -35,8 +35,7 @@ module.exports = (app, server, callback) ->
     # initialize device authentication
     # reset (load) and display the routes
 
-    remoteAccess.updateCredentials 'Device', () ->
-        remoteAccess.updateCredentials 'Sharing', () ->
-            router.reset ->
-                router.displayRoutes ->
-                    callback app, server
+    remoteAccess.updateCredentials () ->
+        router.reset ->
+            router.displayRoutes ->
+                callback app, server


### PR DESCRIPTION
This PR makes the authentication generic for all purposes (devices, serverless apps, sharing, ...)