### PR TITLE
Fixed a potential crash

### DIFF
--- a/server/middlewares/authentication.coffee
+++ b/server/middlewares/authentication.coffee
@@ -53,26 +53,27 @@ module.exports.authenticate = (req, res, next) ->
         else if not user and user isnt undefined
             msg = localization.t "error otp invalid code"
             User.first (err, user) ->
-                recoveryCodes = user.encryptedRecoveryCodes[0]
-                if parseInt(req.body.authcode) in recoveryCodes
-                    # Disabling recovery code
-                    index = recoveryCodes.indexOf(parseInt req.body.authcode)
-                    recoveryCodes.splice index, 1
-                    user.updateAttributes
-                        encryptedRecoveryCodes: recoveryCodes
-                    , ->
-                        # Allowing the authentication
-                        str = localization.t "authenticated with recovery code"
-                        str += recoveryCodes.length + " "
-                        str += localization.t "recovery codes left"
-                        notificationHelper.createTemporary
-                            text: str
+                codes = user.encryptedRecoveryCodes[0]
+                if typeof codes isnt undefined
+                    if parseInt(req.body.authcode) in codes
+                        # Disabling recovery code
+                        index = codes.indexOf(parseInt req.body.authcode)
+                        codes.splice index, 1
+                        user.updateAttributes
+                            encryptedRecoveryCodes: codes
                         , ->
-                            if recoveryCodes.length is 0
-                                str = localization.t "recovery codes warning"
-                                notificationHelper.createTemporary
-                                    text: str
-                            authSuccess()
+                            # Allowing the authentication
+                            str = localization.t "authenticated with recovery code"
+                            str += codes.length + " "
+                            str += localization.t "recovery codes left"
+                            notificationHelper.createTemporary
+                                text: str
+                            , ->
+                                if codes.length is 0
+                                    str = localization.t "recovery codes warning"
+                                    notificationHelper.createTemporary
+                                        text: str
+                                authSuccess()
                 else
                     error = new Error msg
                     error.status = 401


### PR DESCRIPTION
If the user has already enabled 2FA before applying the update bringing recovery tokens, its proxy can crash whenever it inputs a wrong 2FA token, because the array containing them doesn't exist yet.