### PR TITLE
Fixed a crash (and a wrong table splice)

### DIFF
--- a/server/middlewares/authentication.coffee
+++ b/server/middlewares/authentication.coffee
@@ -37,8 +37,9 @@ createNotificationRecovery = (length, callback)->
     notificationHelper.createTemporary {text} , callback
 
 disableRecoveryCode = (user, codes, index, callback) ->
-    changes = encryptedRecoveryCodes: JSON.stringify(codes.splice index, 1)
-    user.updateAttributes  codes, changes, callback
+    codes.splice index, 1
+    changes = encryptedRecoveryCodes: JSON.stringify(codes)
+    user.updateAttributes changes, callback
 
 attemptRecoveryCodes = (user, req, res, next) ->
     User.first (err, user) ->


### PR DESCRIPTION
Fixed the proxy causing an error due to a wrong usage of the `updateAttribute` method (we don't need to specify the old values). Because of that, `cozydb` couldn't find the callback and prompted an error without any response being sent to the client.

While I was working on this fix, I also noticed a wrong usage of `Array`'s `splice` method: as described [here](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Array/splice) the return value is an array containing the removed elements, while the original gets this/these element(s) removed. So we were updating the user's recovery codes with an array containing exclusively the code we wanted to remove, instead of an array containing all the recovery codes except this one. Fixed it too.