### PR TITLE
Update Marionnette version to avoid Backbone conflicts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "backbone": "1.3.3",
-    "backbone.marionette": "2.4.5",
+    "backbone.marionette": "2.4.6",
     "baconjs": "0.7.84",
     "jquery": "2.2.3",
     "node-polyglot": "2.0.0",


### PR DESCRIPTION
I was experiencing this error in my environment when trying to run cozy-proxy.

```
backbone.marionette.js:3232 Uncaught TypeError: Cannot read property 'radio' of undefined
```

@CPatchane was not able to reproduce on his own environment.

First fix was to follow this Stack Overflow answer :
http://stackoverflow.com/questions/35802424/backbone-marionette-and-webpack-uncaught-typeerror-cannot-read-property-radi
and update webpack.config.js
```json
resolve: {
    alias: {
        backbone: path.join(__dirname, 'node_modules', 'backbone', 'backbone')
    }
}
```

As this fix gave us evidence of a Backbone version problem, we investigated this option.
We finally discovered that updating Marionette version in `client/package.json` was also fixing my environment, and was still working on @CPatchane's one.