### PR TITLE
Add active steps detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ before_install:
 
 script:
     - npm run build
-    - npm run test:build
 
 after_failure:
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_install:
 
 script:
     - npm run build
+    - npm run test
 
 after_failure:
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ branches:
   except:
     - demo
 node_js:
-    - 0.10
-    - 0.12
     - 4
     - 5
 services:

--- a/client/app/config/steps/all.coffee
+++ b/client/app/config/steps/all.coffee
@@ -3,12 +3,14 @@
 # At this time there is only proper
 welcome = require './welcome'
 agreement = require './agreement'
+infos = require './infos'
 password = require './password'
 confirmation = require './confirmation'
 
 module.exports = [
     welcome,
     agreement,
+    infos,
     password,
     confirmation
 ]

--- a/client/app/config/steps/infos.coffee
+++ b/client/app/config/steps/infos.coffee
@@ -1,0 +1,16 @@
+timezones = require '../../lib/timezones'
+EmailHelper = require '../../lib/email_helper'
+
+isValidTimezone = (timezone) ->
+    return timezone? and not(timezones.indexOf(timezone) is -1)
+
+isValidEmail = (email) ->
+    return email? and EmailHelper.check(email)
+
+module.exports = {
+    name: 'infos',
+    route: 'infos',
+    view : 'steps/infos',
+    isActive: (user) ->
+        return not (isValidTimezone(user.timezone) and isValidEmail(user.email))
+}

--- a/client/app/lib/email_helper.coffee
+++ b/client/app/lib/email_helper.coffee
@@ -1,0 +1,6 @@
+# Check validity of an email. Borrowed from server/lib/helpers.coffee
+module.exports.check = (email) ->
+    # coffeelint: disable=max_line_length
+    re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    # coffeelint: enable=max_line_length
+    return email? and email.length > 0 and re.test(email)

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -30,7 +30,7 @@ class Step
     # @param user : plain JS object. Not used in this abstract default method
     #  but should be in overriding ones.
     isActive: (user) ->
-        return true;
+        return true
 
     # Submit the step
     # This method should be overriden by step given as parameter to add

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -59,8 +59,7 @@ module.exports = class Onboarding
                 stepModel = new Step step
                 if stepModel.isActive user
                     activeSteps.push stepModel
-                    stepModel.onValidated () =>
-                        @handleStepSubmitted()
+                    stepModel.onValidated @handleStepSubmitted
                 return activeSteps
             , []
 
@@ -77,7 +76,7 @@ module.exports = class Onboarding
     # when it has been successfully submitted
     # Maybe validation should be called here
     # Maybe we will return a Promise or call some callbacks in the future.
-    handleStepSubmitted: () ->
+    handleStepSubmitted: =>
         @goToNext()
 
 

--- a/client/app/views/steps/infos.coffee
+++ b/client/app/views/steps/infos.coffee
@@ -1,0 +1,10 @@
+{LayoutView} = require 'backbone.marionette'
+
+module.exports = class InfosView extends LayoutView
+    template: require '../templates/view_steps_infos'
+
+    events:
+        'click button': 'onSubmit'
+
+    onSubmit: (event)->
+        @model.submit()

--- a/client/app/views/templates/view_steps_agreement.jade
+++ b/client/app/views/templates/view_steps_agreement.jade
@@ -1,5 +1,5 @@
 extends view_base
 
 block region
-    h1= 'Conditions générales'
-    button='CONTINUER'
+    h1=t('Conditions générales')
+    button=t('CONTINUER')

--- a/client/app/views/templates/view_steps_confirmation.jade
+++ b/client/app/views/templates/view_steps_confirmation.jade
@@ -1,5 +1,5 @@
 extends view_base
 
 block region
-    h1= 'Votre Cozy a bien été créé'
-    button='CONTINUER'
+    h1=t('Votre Cozy a bien été créé')
+    button=t('CONTINUER')

--- a/client/app/views/templates/view_steps_infos.jade
+++ b/client/app/views/templates/view_steps_infos.jade
@@ -1,0 +1,5 @@
+extends view_base
+
+block region
+    h1= 'Complétez votre Cozy'
+    button='CONTINUER'

--- a/client/app/views/templates/view_steps_infos.jade
+++ b/client/app/views/templates/view_steps_infos.jade
@@ -1,5 +1,5 @@
 extends view_base
 
 block region
-    h1= 'Complétez votre Cozy'
-    button='CONTINUER'
+    h1=t('Complétez votre Cozy')
+    button=t('CONTINUER')

--- a/client/app/views/templates/view_steps_password.jade
+++ b/client/app/views/templates/view_steps_password.jade
@@ -1,6 +1,6 @@
 extends view_base
 
 block region
-    h1= 'Votre mot de passe'
+    h1=t('Votre mot de passe')
     input(type="password", name="password")
-    button='CONTINUER'
+    button=t('CONTINUER')

--- a/client/app/views/templates/view_steps_welcome.jade
+++ b/client/app/views/templates/view_steps_welcome.jade
@@ -1,5 +1,5 @@
 extends view_base
 
 block region
-    h1= 'Bonjour Claude'
-    button='CONTINUER'
+    h1=t('Bonjour Claude')
+    button=t('CONTINUER')

--- a/client/doc/onboarding.md
+++ b/client/doc/onboarding.md
@@ -61,6 +61,30 @@ Go directly to the given step and trigger required events. Useful for go back in
 Returns a step by its name.
 
 ### Step
+
+#### isActive(user)
+* `user`: JS Object
+
+Returns true if the step has to be active for the given `user`. Returns `true` by default.
+This method can be overriden by specifying an `isActive` method in constructor parameter.
+
+##### Example
+```javascript
+let step = new Step({
+    isActive: (user) => {
+        // This step will be active only for Claude
+        return user.name === 'Claude'
+    }
+});
+
+let result1 = step.isActive({name: Claude});
+// result1 = true
+
+let result2 = step.isActive({name: Claudia});
+// result = false
+```
+
+
 #### onSubmitted(callback)
 ##### Parameters
 * `callback`: function

--- a/client/test/config/steps/infos.js
+++ b/client/test/config/steps/infos.js
@@ -1,0 +1,50 @@
+'use strict';
+let assert = require('chai').assert;
+
+let infos = require('../../../app/config/steps/infos.coffee');
+
+describe('Step: infos', () => {
+    describe('#isActive', () => {
+        it('should return true for user with invalid email', () => {
+            // arrange
+            let user = {
+                email: '',
+                timezone: 'Europe/Paris'
+            };
+
+            // act
+            let result = infos.isActive(user);
+
+            // assert
+            assert.isTrue(result);
+        });
+
+        it('should return true for user with invalid timezone', () => {
+            // arrange
+            let user = {
+                email: 'claude@example.org',
+                timezone: 'not a timezone'
+            };
+
+            // act
+            let result = infos.isActive(user);
+
+            // assert
+            assert.isTrue(result);
+        });
+
+        it('should return false for user with valid email and timezone', () => {
+            // arrange
+            let user = {
+                email: 'claude@example.org',
+                timezone: 'Europe/Paris'
+            };
+
+            // act
+            let result = infos.isActive(user);
+
+            // assert
+            assert.isFalse(result);
+        });
+    });
+})

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -82,27 +82,6 @@ describe('Onboarding', () => {
             assert.isFunction(step2.submit);
         });
 
-        it('should not map unexpected steps properties', () => {
-            // arrange
-            let user = null;
-            let steps = [{
-                name: 'test',
-                route: 'testroute',
-                view: 'testview',
-                unexpected: 'do not map'
-            }];
-
-            // act
-            let onboarding = new Onboarding(user, steps);
-
-            // assert
-            let step = onboarding.steps[0];
-            assert.equal('test', step.name);
-            assert.equal('testroute', step.route);
-            assert.equal('testview', step.view);
-            assert.isUndefined(step.unexpected);
-        });
-
         it('should throw error when `steps` parameter is missing', () => {
             // arrange
             let fn = () => {
@@ -112,6 +91,33 @@ describe('Onboarding', () => {
 
             // assert
             assert.throw(fn, 'Missing mandatory `steps` parameter');
+        });
+
+        it('should not map inActive steps', () => {
+            // arrange
+            // arrange
+            let user = null;
+            let steps = [{
+                name: 'test',
+                route: 'testroute',
+                view: 'testview'
+            }, {
+                name: 'test2',
+                route: 'testroute2',
+                view: 'testview2',
+                isActive: () => false
+            }];
+
+            // act
+            let onboarding = new Onboarding(user, steps);
+
+            // assert
+            assert.equal(1, onboarding.steps.length)
+            let step1 = onboarding.steps[0];
+            assert('Step', step1.constructor.name);
+            assert.equal('test', step1.name);
+            assert.equal('testroute', step1.route);
+            assert.equal('testview', step1.view);
         });
     });
 
@@ -433,7 +439,7 @@ describe('Onboarding.Step', () => {
             assert.equal(result.view, options.view);
         });
 
-        it('should not mal unexpected properties', () => {
+        it('should not map unexpected properties', () => {
             // arrange
             let options = {
                 inject: 'inject'
@@ -444,6 +450,65 @@ describe('Onboarding.Step', () => {
 
             // assert
             assert.isUndefined(result.inject);
+        });
+
+        it('should override default isActive with new one', () => {
+            // arrange
+            let overridingIsActive = (user) => {};
+            let options = {
+                isActive: overridingIsActive
+            };
+
+            // act
+            let step = new Step(options);
+
+            // assert
+            assert.equal(overridingIsActive, step.isActive);
+        });
+    });
+
+    describe('#isActive', () => {
+        it('should return true by default', () => {
+            // arrange
+            let step = new Step();
+
+            // act
+            let result = step.isActive();
+
+            // assert
+            assert.isTrue(result);
+        });
+
+        it('should call overriding method', () => {
+            // arrange
+            let spy = sinon.spy();
+            let step = new Step({
+                isActive: spy
+            });
+
+            // act
+            let result = step.isActive();
+
+            // assert
+            assert(spy.calledOnce);
+        });
+
+        it('should not call overriding method on other steps', () => {
+            // arrange
+            let spy = sinon.spy();
+            let step = new Step({
+                isActive: spy
+            });
+
+            let step2 = new Step();
+
+            // act
+            let result = step.isActive();
+            let result2 = step2.isActive();
+
+            // assert
+            assert(spy.calledOnce);
+            assert.isTrue(result2);
         });
     });
 


### PR DESCRIPTION
Thanks @m4dz to have a review. (ping also @CPatchane and @misstick)

This PR add a way to detect if an onboarding step is active, i.e. it it has to appear in the onboarding flow.

To handle that, it adds an `isActive(user)` method to Onboarding Step class, which specifies if the step has to be active for a given user (See documentation).

This method may be overriden by config steps. See for example infos step.

### Infos step

Also, it add the infos step, only active when given user don't have valid `email` or `timezone`.

### Also added
* Documentation
* Tests