### PR TITLE
Add progression mechanism and progression indicator into views

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -12,6 +12,7 @@ AppLayout = require './views/app_layout'
 
 Onboarding = require './lib/onboarding'
 StepModel = require './models/step'
+ProgressionModel = require './models/progression'
 
 class App extends Application
 
@@ -27,7 +28,10 @@ class App extends Application
         steps = require './config/steps/all'
         @on 'start', (options) =>
 
-            @onboarding = new Onboarding({}, steps)
+            # TODO: Get the user with a better way later
+            user = {}
+
+            @onboarding = new Onboarding(user, steps)
             @onboarding.onStepChanged (step) => @handleStepChanged(step)
 
             @initializeRouter @onboarding.steps
@@ -64,6 +68,8 @@ class App extends Application
             @layout.showChildView 'content',
                 new StepView
                     model: new StepModel step: step
+                    progression: new ProgressionModel \
+                        @onboarding.getProgression step
 
 
     # Internal handler called when the onboarding's internal step has just

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -119,5 +119,17 @@ module.exports = class Onboarding
         return @steps.find (step) ->
             return step.name is stepName
 
+
+    # Returns progression associated to the given step object
+    # @param step Step which we want to know the related progression
+    # returns the current index of the step, from 1 to length. 0 if the step
+    # does not exist in the onboarding.
+    getProgression: (step) ->
+        return \
+            current: @steps.indexOf(step)+1,
+            total: @steps.length,
+            labels: @steps.map (step) -> step.name
+
+
 # Step is exposed for test purposes only
 module.exports.Step = Step

--- a/client/app/models/progression.coffee
+++ b/client/app/models/progression.coffee
@@ -1,0 +1,8 @@
+Backbone = require 'backbone'
+
+# ProgressionModel
+# Backbone wrapper for Onboarding's progression object
+# This object is returned by the method onboarding.getProgression
+# It contains three properties
+# current (int), total (int) and labels (array)
+module.exports = class ProgressionModel extends Backbone.Model

--- a/client/app/views/step.coffee
+++ b/client/app/views/step.coffee
@@ -1,0 +1,20 @@
+{LayoutView} = require 'backbone.marionette'
+Backbone = require 'backbone'
+
+ProgressionView = require './steps/subviews/progression'
+
+module.exports = class StepView extends LayoutView
+
+
+    regions:
+        progression: '.progression'
+
+
+    initialize: (options) ->
+        super(options)
+        @progressionView = new ProgressionView \
+            model: options.progression
+
+
+    onRender: () ->
+        @showChildView 'progression', @progressionView

--- a/client/app/views/steps/agreement.coffee
+++ b/client/app/views/steps/agreement.coffee
@@ -1,6 +1,6 @@
-{LayoutView} = require 'backbone.marionette'
+StepView = require '../step'
 
-module.exports = class AgreementView extends LayoutView
+module.exports = class AgreementView extends StepView
     template: require '../templates/view_steps_agreement'
 
     events:

--- a/client/app/views/steps/confirmation.coffee
+++ b/client/app/views/steps/confirmation.coffee
@@ -1,6 +1,6 @@
-{LayoutView} = require 'backbone.marionette'
+StepView = require '../step'
 
-module.exports = class ConfirmationView extends LayoutView
+module.exports = class ConfirmationView extends StepView
     template: require '../templates/view_steps_confirmation'
 
     events:

--- a/client/app/views/steps/infos.coffee
+++ b/client/app/views/steps/infos.coffee
@@ -1,6 +1,6 @@
-{LayoutView} = require 'backbone.marionette'
+StepView = require '../step'
 
-module.exports = class InfosView extends LayoutView
+module.exports = class InfosView extends StepView
     template: require '../templates/view_steps_infos'
 
     events:

--- a/client/app/views/steps/password.coffee
+++ b/client/app/views/steps/password.coffee
@@ -1,6 +1,6 @@
-{LayoutView} = require 'backbone.marionette'
+StepView = require '../step'
 
-module.exports = class PasswordView extends LayoutView
+module.exports = class PasswordView extends StepView
     template: require '../templates/view_steps_password'
 
     events:

--- a/client/app/views/steps/subviews/progression.coffee
+++ b/client/app/views/steps/subviews/progression.coffee
@@ -1,4 +1,4 @@
-{LayoutView} = require 'backbone.marionette'
+{ItemView} = require 'backbone.marionette'
 
-module.exports = class ProgressionView extends LayoutView
+module.exports = class ProgressionView extends ItemView
     template: require '../../templates/progression'

--- a/client/app/views/steps/subviews/progression.coffee
+++ b/client/app/views/steps/subviews/progression.coffee
@@ -1,0 +1,4 @@
+{LayoutView} = require 'backbone.marionette'
+
+module.exports = class ProgressionView extends LayoutView
+    template: require '../../templates/progression'

--- a/client/app/views/steps/welcome.coffee
+++ b/client/app/views/steps/welcome.coffee
@@ -1,6 +1,6 @@
-{LayoutView} = require 'backbone.marionette'
+StepView = require '../step'
 
-module.exports = class WelcomeView extends LayoutView
+module.exports = class WelcomeView extends StepView
     template: require '../templates/view_steps_welcome'
 
     events:

--- a/client/app/views/templates/progression.jade
+++ b/client/app/views/templates/progression.jade
@@ -1,0 +1,3 @@
+ol
+    each label, i in labels
+        li(aria-selected=i==current-1)=label

--- a/client/app/views/templates/view_steps_agreement.jade
+++ b/client/app/views/templates/view_steps_agreement.jade
@@ -2,4 +2,7 @@ extends view_base
 
 block region
     h1=t('Conditions générales')
-    button=t('CONTINUER')
+    footer
+        .controls
+            button=t('CONTINUER')
+        .progression

--- a/client/app/views/templates/view_steps_confirmation.jade
+++ b/client/app/views/templates/view_steps_confirmation.jade
@@ -2,4 +2,7 @@ extends view_base
 
 block region
     h1=t('Votre Cozy a bien été créé')
-    button=t('CONTINUER')
+    footer
+        .controls
+            button=t('CONTINUER')
+        .progression

--- a/client/app/views/templates/view_steps_infos.jade
+++ b/client/app/views/templates/view_steps_infos.jade
@@ -2,4 +2,7 @@ extends view_base
 
 block region
     h1=t('Complétez votre Cozy')
-    button=t('CONTINUER')
+    footer
+        .controls
+            button=t('CONTINUER')
+        .progression

--- a/client/app/views/templates/view_steps_password.jade
+++ b/client/app/views/templates/view_steps_password.jade
@@ -3,4 +3,7 @@ extends view_base
 block region
     h1=t('Votre mot de passe')
     input(type="password", name="password")
-    button=t('CONTINUER')
+    footer
+        .controls
+            button=t('CONTINUER')
+        .progression

--- a/client/app/views/templates/view_steps_welcome.jade
+++ b/client/app/views/templates/view_steps_welcome.jade
@@ -2,4 +2,7 @@ extends view_base
 
 block region
     h1=t('Bonjour Claude')
-    button=t('CONTINUER')
+    footer
+        .controls
+            button=t('CONTINUER')
+        .progression

--- a/client/doc/onboarding.md
+++ b/client/doc/onboarding.md
@@ -60,6 +60,35 @@ Go directly to the given step and trigger required events. Useful for go back in
 
 Returns a step by its name.
 
+#### getProgression(step)
+#### Parameters
+* `step`: Step
+
+Returns a JS object representing the progression in onboarding for the given `step`. This object contains the following properties :
+* `current` (int): The current index, from 1 to the number of steps in the onboarding. 0 means that the step is not in the onboarding steps list.
+* `total` (int): Total number of steps in the onboarding.
+* `labels` (Array): Used for accessibility in views. It an ordered list of all the step names. Should be used as keys for Transifex.
+
+#### Example
+```javascript
+let user = retrieveUserInAWayOrAnother();
+let step1Options = {name: 'example1'};
+let step2Options = {name: 'example2'};
+
+let onboarding = new Onboarding(user, [step1, step2]);
+
+let step2 = onboarding.getStepByName('example2');
+let progression = onboarding.getProgression(step);
+```
+progression will be
+```javascript
+{
+    current: 2,
+    total: 2,
+    labels: ['example1', 'example2']
+}
+```
+
 ### Step
 
 #### isActive(user)

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -414,6 +414,148 @@ describe('Onboarding', () => {
             assert.isUndefined(result);
         });
     });
+
+    describe('#getProgression', () => {
+        it('should return expected total', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let step = onboarding.getStepByName('test');
+
+            // act
+            let result = onboarding.getProgression(step);
+
+            // assert
+            assert.equal(3, result.total);
+        });
+
+        it('should return first step as current', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let step = onboarding.getStepByName('test');
+
+            // act
+            onboarding.goToStep(step);
+            let result = onboarding.getProgression(step);
+
+            // assert
+            assert.equal(1, result.current);
+        });
+
+        it('should return expected current', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let step = onboarding.getStepByName('test2');
+
+            // act
+            onboarding.goToStep(step);
+            let result = onboarding.getProgression(step);
+
+
+            // assert
+            assert.equal(2, result.current);
+        });
+
+        it('should return last step as current', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let step = onboarding.getStepByName('test3');
+
+            // act
+            onboarding.goToStep(step);
+            let result = onboarding.getProgression(step);
+
+
+            // assert
+            assert.equal(3, result.current);
+        });
+
+        it('should return expected labels', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+            let step = onboarding.getStepByName('test');
+            let expectedLabels = ['test', 'test2', 'test3'];
+
+            // act
+            let result = onboarding.getProgression(step);
+
+            // assert
+            assert.deepEqual(expectedLabels, result.labels);
+        });
+    });
 });
 
 describe('Onboarding.Step', () => {


### PR DESCRIPTION
Will not work without #307. I tried with this PR to push a rebased version of my branch to isolate only commits related to the progression feature.

This PR adds the method `getProgression(step)` to Onboarding class.

It also implements the logic to get it displayed into views.

## Important changes

This PR introduce a StepView "abstract" class. All step views now inherit from this class.

The markup used in views for progression indicator is the same than the proposed one in @m4dz's PR #305. So all step view templates are changing a little bit but it is absolutely not their final version.

Also added :
* Tests
* Documentation