### PR TITLE
Update Marionnette version to avoid Backbone conflicts (bis)

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -133,6 +133,12 @@ module.exports = {
         filename: optimize? 'app.[hash].js' : 'app.js',
         chunkFilename: optimize? 'register.[hash].js' : 'register.js'
     },
+    alias: {
+      // Force all modules to use versions of backbone and underscore defined
+      // in package.json to prevent duplicate dependencies
+      'backbone': path.join(__dirname, 'node_modules', 'backbone', 'backbone.js'),
+      'underscore': path.join(__dirname, 'node_modules', 'underscore', 'underscore.js')
+    },
     resolve: {
         extensions: ['', '.js', '.coffee', '.jade', '.json']
     },


### PR DESCRIPTION
See previous PR : https://github.com/cozy/cozy-proxy/pull/302

You will find history and complete description of the issue here: 
https://github.com/marionettejs/backbone.marionette/issues/2559#issuecomment-106037738


There was missing webpack configuration to link to the right path when calling package `backbone` or `marionette`