### PR TITLE
[chore] split stylesheets

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -5,9 +5,6 @@ Main application that create a Mn.Application singleton and exposes it. Needs
 router and app_layout view.
 ###
 
-require 'normalize.css/normalize.css'
-require './styles/app.styl'
-
 {Application} = require 'backbone.marionette'
 
 Router    = require './routes'

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -75,6 +75,9 @@ class App extends Application
 
     # Register is the default main route for Onboarding
     handleStepRoute: (stepName='preset') ->
+        # Load onboarding stylesheet
+        AppStyles = require './styles/onboarding.styl'
+
         step = @onboarding.getStepByName stepName
         throw new Error 'Step does not exist' unless step
         @onboarding.goToStep @onboarding.getStepByName stepName

--- a/client/app/routes/index.coffee
+++ b/client/app/routes/index.coffee
@@ -35,6 +35,9 @@ module.exports = class Router extends Backbone.Router
     the submitted form.
     ###
     auth: (path, options) ->
+        # Load app stylesheet
+        AppStyles = require '../styles/app.styl'
+
         AuthView  = require '../views/auth'
         AuthModel = require '../states/auth'
 
@@ -74,6 +77,9 @@ module.exports = class Router extends Backbone.Router
     component determined by the step param.
     ###
     register: (step = 'preset') -> require.ensure [], =>
+        # Load onboarding stylesheet
+        AppStyles = require '../styles/onboarding.styl'
+
         RegisterView      = require '../views/register'
         RegistrationModel = require '../states/registration'
 

--- a/client/app/routes/index.coffee
+++ b/client/app/routes/index.coffee
@@ -77,9 +77,6 @@ module.exports = class Router extends Backbone.Router
     component determined by the step param.
     ###
     register: (step = 'preset') -> require.ensure [], =>
-        # Load onboarding stylesheet
-        AppStyles = require '../styles/onboarding.styl'
-
         RegisterView      = require '../views/register'
         RegistrationModel = require '../states/registration'
 

--- a/client/app/styles/onboarding.styl
+++ b/client/app/styles/onboarding.styl
@@ -1,0 +1,3 @@
+/**
+ * OnBoarding Styles
+ */

--- a/client/app/views/app_layout.coffee
+++ b/client/app/views/app_layout.coffee
@@ -5,6 +5,10 @@ Attach itself to the `[role=application] DOM node and declares the application
 main region for its subviews.
 ###
 
+# Normalize styles
+require 'normalize.css/normalize.css'
+
+
 {LayoutView} = require 'backbone.marionette'
 
 

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,6 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "assets-webpack-plugin": "3.4.0",
     "autoprefixer": "6.3.6",
     "browser-sync": "2.11.2",
     "browser-sync-webpack-plugin": "1.0.1",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,14 +1,21 @@
 var path = require('path');
+var fs   = require('fs');
 
 var webpack = require('webpack');
 
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyPlugin        = require('copy-webpack-plugin');
-var AssetsPlugin      = require('assets-webpack-plugin');
 var BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
 // use the `OPTIMIZE` env VAR to switch from dev to production build
 var optimize = process.env.OPTIMIZE === 'true';
+
+
+// Stylesheets extractors
+var CSSCommon     = new ExtractTextPlugin(optimize? 'common.[hash].css' : 'common.css')
+var CSSApp        = new ExtractTextPlugin(optimize? 'app.[hash].css' : 'app.css')
+var CSSOnBoarding = new ExtractTextPlugin(optimize? 'onboarding.[hash].css' : 'onboarding.css', {allChunks: true})
+
 
 /**
  * Loaders used by webpack
@@ -26,13 +33,17 @@ var loaders = [
         loader: 'coffee'
     },
     {
-        test: /\.styl$/,
-        loader: ExtractTextPlugin.extract('style', cssOptions + '!stylus')
+        test: /app\.styl$/,
+        loader: CSSApp.extract('style', cssOptions + '!stylus')
+    },
+    {
+        test: /onboarding\.styl$/,
+        loader: CSSOnBoarding.extract('style', cssOptions + '!stylus')
     },
     {
         test: /\.css$/,
         exclude: /vendor/,
-        loader: ExtractTextPlugin.extract('style', cssOptions)
+        loader: CSSCommon.extract('style', cssOptions)
     },
     {
         test: /\.jade$/,
@@ -69,7 +80,9 @@ var loaders = [
  *   http://localhost:3000, proxified to the server app port
  */
 var plugins = [
-    new ExtractTextPlugin(optimize? 'app.[hash].css' : 'app.css'),
+    CSSCommon,
+    CSSApp,
+    CSSOnBoarding,
     new webpack.optimize.CommonsChunkPlugin({
         name:      'main',
         children:  true,
@@ -82,9 +95,6 @@ var plugins = [
 
 if (optimize) {
     plugins = plugins.concat([
-        new AssetsPlugin({
-            filename: '../build/webpack-assets.json'
-        }),
         new webpack.optimize.DedupePlugin(),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.optimize.UglifyJsPlugin({
@@ -97,7 +107,15 @@ if (optimize) {
             __SERVER__:      !optimize,
             __DEVELOPMENT__: !optimize,
             __DEVTOOLS__:    !optimize
-        })
+        }),
+        function() {
+            this.plugin("done", function(stats) {
+                fs.writeFileSync(
+                    path.join(__dirname, '..', 'build', 'assets.json'),
+                    '{"hash":"' + stats.hash + '"}'
+                );
+            });
+        }
     ]);
 } else {
     plugins = plugins.concat([

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -39,7 +39,7 @@ module.exports.registerIndex = (req, res, next) ->
 
         else
             localization.setLocale req.headers['accept-language']
-            res.render 'index', env: env
+            res.render 'index', {env: env, onBoarding: true}
 
 
 module.exports.register = (req, res, next) ->

--- a/server/initialize.coffee
+++ b/server/initialize.coffee
@@ -20,15 +20,13 @@ module.exports = (app, server, callback) ->
     app.locals.t         = localization.t
     app.locals.getLocale = localization.getLocale
 
-    # Try to get assets definitions from root (only valid in build, not on
-    # watch mode)
+    # Try to get assets definitions from root
+    # (only valid in build, not on watch mode)
     try
-        assets = require(path.join __dirname, '../webpack-assets').main
+        hash = ".#{require('../assets').hash}"
     catch
-        assets =
-            js: 'app.js'
-            css: 'app.css'
-    app.locals.assets = assets
+        hash = ''
+    app.locals.hash = hash
 
     # initialize Proxy server
     initializeProxy app, server

--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -19,4 +19,4 @@ block js
     if env
         script.
             ENV = !{JSON.stringify(env)};
-    script(src="/#{assets.js}" defer=true)
+    script(src="/app#{hash}.js" defer=true)

--- a/server/views/layouts/_base.jade
+++ b/server/views/layouts/_base.jade
@@ -27,7 +27,8 @@ html(lang=getLocale().language)
         meta(name="theme-color", content="#20a8f1")
 
         link(rel="stylesheet", href="/fonts/fonts.css")
-        link(rel="stylesheet", href="/#{assets.css}")
+        link(rel="stylesheet", href="/common#{hash}.css")
+        link(rel="stylesheet", href="/#{onBoarding?'onboarding':'app'}#{hash}.css")
 
         block js
 


### PR DESCRIPTION
This PR introduces a split in stylesheet from thje webpack config. It let us keep old proxy styles and work to new onboarding in parallel (new styles coming from `client/app/styles/onboarding.styl`). Common CSS (like normalize) are output in a dedicated `common.css` target.