### PR TITLE
Add getNextStep method to Onboarding

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -65,9 +65,10 @@ class App extends Application
     initializeStepRoute: (step) =>
         StepView = require "./views/#{step.view}"
         @router.route "#{step.route}", "route:#{step.route}", () =>
+            nextStep = @onboarding.getNextStep step
             @layout.showChildView 'content',
                 new StepView
-                    model: new StepModel step: step
+                    model: new StepModel step: step, next: nextStep
                     progression: new ProgressionModel \
                         @onboarding.getProgression step
 

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -130,5 +130,24 @@ module.exports = class Onboarding
             labels: @steps.map (step) -> step.name
 
 
+    # Returns next step for the given step. Useful for knowing wich route to
+    # use in a link-to-next.
+    getNextStep: (step) ->
+        if not step
+            throw new Error 'Mandatory parameter step is missing'
+
+        stepIndex = @steps.indexOf step
+
+        if stepIndex is -1
+            throw new Error 'Given step missing in onboarding step list'
+
+        nextStepIndex = stepIndex+1
+
+        if nextStepIndex is @steps.length
+            return null
+
+        return @steps[nextStepIndex]
+
+
 # Step is exposed for test purposes only
 module.exports.Step = Step

--- a/client/app/models/step.coffee
+++ b/client/app/models/step.coffee
@@ -9,13 +9,15 @@ module.exports = class StepModel extends Backbone.Model
     # Map needed property to current model
     # @param
     #  * step An onboarding Step object (see lib/onboarding)
-    initialize: ({step}) ->
+    initialize: ({step, next}) ->
         @step = step
 
         # We map the defaults steps properties in the current model
         # There will be more properties/functions in the future.
         ['name', 'route', 'view'].forEach (property) =>
             @set property, step[property]
+
+        @set 'next', next
 
     # Encapsulate call to step.submit
     submit: () ->

--- a/client/doc/onboarding.md
+++ b/client/doc/onboarding.md
@@ -69,6 +69,16 @@ Returns a JS object representing the progression in onboarding for the given `st
 * `total` (int): Total number of steps in the onboarding.
 * `labels` (Array): Used for accessibility in views. It an ordered list of all the step names. Should be used as keys for Transifex.
 
+#### getNextStep(step)
+##### Parameters
+* `step`: Step
+
+Returns the next Step in onboarding step list.
+
+Returns null if the given step is the last one.
+
+Throw error if step does not exist in onboarding step list or if step parameter is missing.
+
 #### Example
 ```javascript
 let user = retrieveUserInAWayOrAnother();

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -556,6 +556,123 @@ describe('Onboarding', () => {
             assert.deepEqual(expectedLabels, result.labels);
         });
     });
+
+    describe('#getNextStep', () => {
+        it('should throw error when no step is given in parameter', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let fn = () => {
+                // act
+                let result = onboarding.getNextStep();
+            };
+
+            // assert
+            assert.throw(fn, 'Mandatory parameter step is missing');
+        });
+
+        it('should throw error when given step is not in step list', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let otherStep = new Step({
+                name: 'otherStep',
+                route: 'otherRoute',
+                view: 'otherView'
+            });
+
+            let fn = () => {
+                // act
+                let result = onboarding.getNextStep(otherStep);
+            };
+
+            // assert
+            assert.throw(fn, 'Given step missing in onboarding step list');
+        });
+
+        it('should return next step', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let step1 = onboarding.getStepByName('test');
+            let step2 = onboarding.getStepByName('test2');
+
+            // act
+            let result = onboarding.getNextStep(step1);
+
+            // assert
+            assert.equal(step2, result);
+        });
+
+        it('should return null when current step is last step', () => {
+            // arrange
+            let onboarding = new Onboarding(null, [
+                {
+                    name: 'test',
+                    route: 'testroute',
+                    view: 'testview'
+                }, {
+                    name: 'test2',
+                    route: 'testroute2',
+                    view: 'testview2'
+                }, {
+                    name: 'test3',
+                    route: 'testroute3',
+                    view: 'testview3'
+                }
+            ]);
+
+            let step3 = onboarding.getStepByName('test3');
+
+            // act
+            let result = onboarding.getNextStep(step3);
+
+            // assert
+            assert.isNull(result);
+        });
+    });
 });
 
 describe('Onboarding.Step', () => {


### PR DESCRIPTION
To be able to add a accessible link to next step into views, we need to have a `getNextStep` method on Onboarding class.

This next step is then given to Backbone StepModel as `next` property.

In views, we can access next step's route by using `next.route`.

Thanks @m4dz to have a review.