### PR TITLE
Retrieve user data for onboarding

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -28,8 +28,9 @@ class App extends Application
         steps = require './config/steps/all'
         @on 'start', =>
 
-            # TODO: Get the user with a better way later
-            user = {}
+            user = {
+                username: ENV.username
+            }
 
             @onboarding = new Onboarding(user, steps)
             @onboarding.onStepChanged (step) => @handleStepChanged(step)

--- a/client/app/config/steps/accounts.coffee
+++ b/client/app/config/steps/accounts.coffee
@@ -1,0 +1,5 @@
+module.exports = {
+    name: 'accounts', # named 'preset' to match existing codebase.
+    route: 'accounts',
+    view : 'steps/accounts'
+}

--- a/client/app/config/steps/accounts.coffee
+++ b/client/app/config/steps/accounts.coffee
@@ -1,5 +1,5 @@
 module.exports = {
-    name: 'accounts', # named 'preset' to match existing codebase.
+    name: 'accounts',
     route: 'accounts',
-    view : 'steps/accounts'
+    view: 'steps/accounts'
 }

--- a/client/app/config/steps/all.coffee
+++ b/client/app/config/steps/all.coffee
@@ -5,6 +5,7 @@ welcome = require './welcome'
 agreement = require './agreement'
 infos = require './infos'
 password = require './password'
+accounts = require './accounts'
 confirmation = require './confirmation'
 
 module.exports = [
@@ -12,5 +13,6 @@ module.exports = [
     agreement,
     infos,
     password,
+    accounts,
     confirmation
 ]

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -3,10 +3,26 @@ class Step
     # Retrieves properties from config Step plain object
     # @param step : config step, i.e. plain object containing custom properties
     #   and methods.
-    constructor: (step={}) ->
-        ['name', 'route', 'view', 'isActive'].forEach (property) =>
+    constructor: (step={}, user={}) ->
+        [
+          'name',
+          'route',
+          'view',
+          'isActive',
+          'fetchUser'
+        ].forEach (property) =>
             if step[property]
                 @[property] = step[property]
+
+        @fetchUser user
+
+
+    # Map some user properties to current step object
+    # @param user : JS object representing the user.
+    # This method can be overriden by passing another fetchUser function
+    # in constructor parameters
+    fetchUser: (user={}) ->
+        @username = user.username
 
 
     # Record handlers for 'completed' internal pseudo-event
@@ -55,7 +71,7 @@ module.exports = class Onboarding
         @user = user
         @steps = steps
             .reduce (activeSteps, step) =>
-                stepModel = new Step step
+                stepModel = new Step step, user
                 if stepModel.isActive user
                     activeSteps.push stepModel
                     stepModel.onCompleted @handleStepCompleted

--- a/client/app/models/step.coffee
+++ b/client/app/models/step.coffee
@@ -14,7 +14,7 @@ module.exports = class StepModel extends Backbone.Model
 
         # We map the defaults steps properties in the current model
         # There will be more properties/functions in the future.
-        ['name', 'route', 'view'].forEach (property) =>
+        ['name', 'route', 'view', 'username'].forEach (property) =>
             @set property, step[property]
 
         @set 'next', next

--- a/client/app/views/steps/accounts.coffee
+++ b/client/app/views/steps/accounts.coffee
@@ -1,0 +1,10 @@
+StepView = require '../step'
+
+module.exports = class AccountsView extends StepView
+    template: require '../templates/view_steps_accounts'
+
+    events:
+        'click button': 'onSubmit'
+
+    onSubmit: (event)->
+        @model.submit()

--- a/client/app/views/templates/view_steps_accounts.jade
+++ b/client/app/views/templates/view_steps_accounts.jade
@@ -1,0 +1,8 @@
+extends view_base
+
+block region
+    h1=t('Vos comptes')
+    footer
+        .controls
+            button=t('CONTINUER')
+        .progression

--- a/client/doc/onboarding.md
+++ b/client/doc/onboarding.md
@@ -101,6 +101,39 @@ progression will be
 
 ### Step
 
+#### constructor(options, user)
+* `options`: JS Object containing step properties and specific methods
+* `user`: JS Object containing user properties
+
+#### fetchUser(user)
+* `user`: JS Object
+
+Map some given user properties to the step. By default, the method just map the `username` for every step.
+
+This method may be overriden by specifying a `fetchUser` method in constructor parameter.
+
+__This method is called in the constructor__.
+
+##### Example
+```javascript
+let user = {
+    username: 'Claude',
+    email: 'claude@example.org'
+};
+
+let step = new Step({
+    fetchUser: (user) => {
+        @username = user.username
+        @useremail = user.email
+    }, user
+});
+
+console.log(step.username);
+// > Claude
+console.log(step.useremail);
+// > claude@example.org
+```
+
 #### isActive(user)
 * `user`: JS Object
 

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -846,4 +846,46 @@ describe('Onboarding.Step', () => {
             assert(step.triggerCompleted.calledOnce);
         });
     });
+
+    describe('#fetchUser', () => {
+        it('should fetch username by default', () => {
+            // arrange
+            let username = 'Claude';
+
+            // act
+            let step = new Step({}, {username: username});
+
+            // assert
+            assert.equal(username, step.username);
+        });
+
+        it('should call overriding method', () => {
+            // arrange
+            let spy = sinon.spy();
+
+            // act
+            // fetchUser is called in constructor
+            let step = new Step({
+                fetchUser: spy
+            });
+
+            // assert
+            assert(spy.calledOnce);
+        });
+
+        it('should not call overriding method on other steps', () => {
+            // arrange
+            let spy = sinon.spy();
+
+            // act
+            let step = new Step({
+                fetchUser: spy
+            });
+
+            let step2 = new Step();
+
+            // assert
+            assert(spy.calledOnce);
+        });
+    });
 });


### PR DESCRIPTION
It used the the same mechanism as the previous version : pass the username into ENV variable and retrieve in `Application`.

Also, this PR adds the "accounts" step.

(I finally decided to separate this first part from the final PR about welcome step)