### PR TITLE
Onboarding data handling

### DIFF
--- a/client/doc/onboardingDataHandling.md
+++ b/client/doc/onboardingDataHandling.md
@@ -1,0 +1,134 @@
+# Onboarding : user data handling
+
+## Existing
+
+### Model
+
+```coffee
+email: String
+password: String
+salt: String
+public_name: String
+timezone: String
+owner: Boolean
+allow_stats: Boolean
+activated: Boolean
+encryptedOtpKey: String
+hotpCounter: Number
+authType: String
+encryptedRecoveryCodes: Array
+```
+
+### Process
+
+1. Checking ```public_name ``` property existance from ```user``` document (server side).
+2. __If__ ```public_name ``` __exists__, redirection to ```login``` page. __Otherwise__, rendering the front application with, as default, the ```register``` page in order to save ```user``` data.
+3. __If register__, new data for the ```user``` document are saved at the form validation, then redirection to the ```login``` page.
+
+### Issues
+
+* The ```user``` document isn't fully obtained from the server, since all informations are not necessary here for the ```register```.
+* The "choice" between ```register``` and ```login``` is only based on the ```public_name ``` property existance (```user``` document).
+* The ```register``` step is processed only __BEFORE__ the user authentication, which doesn't allow to expose all ```user``` document data.
+
+## Proposition
+
+### Model
+
+```coffee
+email: String
+password: String
+salt: String
+public_name: String
+timezone: String
+owner: Boolean
+allow_stats: Boolean
+activated: Boolean
+encryptedOtpKey: String
+hotpCounter: Number
+authType: String
+encryptedRecoveryCodes: Array
+# new fields below
+onboardedSteps: Array
+# default: []
+# complete: ['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']
+isCGUaccepted: Boolean
+# default: false
+```
+
+### Constraints
+
+* The ```user``` document data mustn't be exposed before user authentication, except ```public_name ``` string and ```hasValidInfos``` boolean only.
+* The existing ```login``` mustn't be broken before its specific refactoring later on.
+* The user can not get back to the previous step.
+* Some steps are reachable only with user authentication : ```infos```, ```accounts``` and ```ending```
+* __Security purpose:__ A token could be used to get reachable the first three onboarding steps, in a secured way and with a unique usage.
+
+### Processes
+
+This process handles the case detection from the ```user``` document and all redirections between onboarding steps and other elements (login page, the cozy home and My Accounts application).
+
+The complete ```onboardedSteps``` value, considered here, is ```['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']```
+
+> Legend:
+> '__=>__' means "__redirect to | go to__"
+
+#### Step situation detection
+
+According to the ```user``` document properties:
+
+* If __```onboardedSteps```__ is __```['welcome']```__ => ```agreement``` step.
+* If __```onboardedSteps```__ is __```['welcome', 'agreement']```__ => ```password``` step.
+* If ```isCGUaccepted``` AND ```password``` AND __```onboardedSteps```__ is __```['welcome', 'agreement', 'password']```__ => ```login``` then ```infos``` step to get ```email``` and ```timezone``` informations.
+* If ```isCGUaccepted``` AND ```password``` AND ```email``` AND ```timezone``` AND ```public_name``` AND __```onboardedSteps```__ is __```['welcome', 'agreement', 'password']```__ => ```login``` then ```accounts``` step with ```onboardedSteps``` set to ```['welcome', 'agreement', 'password', 'infos']``` (skip unecessary ```infos``` step)
+* If __```onboardedSteps```__ is __```['welcome', 'agreement', 'password', 'infos']```__ => ```accounts``` step with user authenticated
+* If __```onboardedSteps ```__ is __```['welcome', 'agreement', 'password', 'infos', 'accounts']```__ => ```ending``` step with authenticated user
+* If __```onboardedSteps ```__ is __```['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']```__ => cozy home with authenticated user
+* If no ```user``` document => ```welcome``` step (without username)
+* If only ```public_name``` => ```welcome``` step (with username)
+* __Default__ => ```welcome``` step with ```onboardedSteps``` set to ```[]```
+
+#### Views data behaviour (client side)
+
+> ```hasValidInfos``` is a boolean used here to know if the onboarding will have 5 or 6 steps (if the user will need the ```infos``` step or not), specially for the progress indicator feature.
+
+1. For ```welcome``` step:
+    * Reachable via ```/onboarding/welcome``` path
+    * Only the ```username``` and ```hasValidInfos``` (if exist) are used throught the view
+    * At validation, ```welcome``` step name are sent to server side to be saved in user ```user``` document (```onboardedSteps``` property)
+2. For ```agreement``` step:
+    * Reachable via ```/onboarding/agreement``` path
+    * Only the ```username``` and ```hasValidInfos``` (if exist) are used throught the view
+    * At validation, ```agreement``` step name and ```{CGUaccepted: true}``` are sent to server side to be saved in ```user``` document
+3. For ```password``` step:
+    * Reachable via ```/onboarding/password``` path
+    * Only the ```username``` and ```hasValidInfos``` (if exist) are used throught the view
+    * At validation, ```password``` step name and ```{password: 'userpasswordhere'}``` are sent to server side to be saved in ```user``` document
+    * At the validation, the user will be redirected to the login page for the authentication
+4. For ```infos``` step:
+    * User __authentication required__
+    * Reachable via ```/onboarding/infos``` path
+    * At the step rendering, the ```user``` document is requested
+    * At validation, ```infos``` step name and ```{email: 'userpasswordhere', public_name: 'username', timezone: 'country/town'}``` are sent to server side to be saved in ```user``` document
+5. For ```accounts``` step:
+    * User __authentication required__
+    * Reachable via ```/onboarding/accounts``` path
+    * At the step validation, the user will be redirected to the "My Accounts" application (using probably an argument to specify that is from the onboarding process)
+    * At the "My accounts" callback, ```accounts``` step name is sent to server side to be saved in ```user``` document
+6. For the ```ending``` step:
+    * User __authentication required__
+    * Reachable via ```/onboarding/ending``` path
+    * The step must be reachable from an URL that follows these rules:
+        * If the ```onboardedSteps ``` is ```['welcome', 'agreement', 'password', 'infos', 'accounts']``` => ```ending``` step
+        * If the ```activated``` is ```false``` AND ```onboardedSteps ``` is ```['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']``` => ```ending``` step
+        * If the ```activated``` is ```true``` AND ```onboardedSteps ``` is ```['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']``` => cozy home
+        * __Default__ => ```welcome``` step with ```onboardedSteps``` set to ```[]```
+
+#### Handle onboarding changes
+
+At the entry connexion (after login or at the home connexion):
+
+* If ```activated``` is ```true```, the ```onboardedSteps``` is compared to the steps hardcoded in the cozy-proxy:
+    * If it's the same => login page then the cozy home as authenticated user (__usual case__)
+    * Otherwise, ```onboardedSteps``` is changed (that means the order or the steps have changed in the proxy) and the user will be redirected to a specific step (or not) according to the ```onboardedSteps``` value. This way will be used when __in case of future onboarding steps updates__.
+* If ```activated``` is ```false```, see server side "Step situation detection" part

--- a/client/doc/onboardingDataHandling.md
+++ b/client/doc/onboardingDataHandling.md
@@ -96,25 +96,66 @@ According to the ```user``` document properties:
     * Reachable via ```/onboarding/welcome``` path
     * Only the ```username``` and ```hasValidInfos``` (if exist) are used throught the view
     * At validation, ```welcome``` step name are sent to server side to be saved in user ```user``` document (```onboardedSteps``` property)
+    * __Save request__ format:
+        ```
+        POST /register
+        {
+            "onboardedSteps": Array(String)
+        }
+        ```
 2. For ```agreement``` step:
     * Reachable via ```/onboarding/agreement``` path
     * Only the ```username``` and ```hasValidInfos``` (if exist) are used throught the view
     * At validation, ```agreement``` step name and ```{CGUaccepted: true}``` are sent to server side to be saved in ```user``` document
+    * __Save request__ format:
+        ```
+        POST /register
+        {
+            "isCGUaccepted": Boolean,
+            "allow_stats": Boolean,
+            "onboardedSteps": Array(String)
+        }
+        ```
 3. For ```password``` step:
     * Reachable via ```/onboarding/password``` path
     * Only the ```username``` and ```hasValidInfos``` (if exist) are used throught the view
     * At validation, ```password``` step name and ```{password: 'userpasswordhere'}``` are sent to server side to be saved in ```user``` document
     * At the validation, the user will be redirected to the login page for the authentication
+    * __Save request__ format:
+        ```
+        POST /register
+        {
+            "password": String,
+            "onboardedSteps": Array(String)
+        }
+        ```
 4. For ```infos``` step:
     * User __authentication required__
     * Reachable via ```/onboarding/infos``` path
     * At the step rendering, the ```user``` document is requested
     * At validation, ```infos``` step name and ```{email: 'userpasswordhere', public_name: 'username', timezone: 'country/town'}``` are sent to server side to be saved in ```user``` document
+    * __Save request__ format:
+        ```
+        PUT /register
+        {
+            "public_name": String,
+            "email": String,
+            "timezone": String,
+            "onboardedSteps": Array(String)
+        }
+        ```
 5. For ```accounts``` step:
     * User __authentication required__
     * Reachable via ```/onboarding/accounts``` path
     * At the step validation, the user will be redirected to the "My Accounts" application (using probably an argument to specify that is from the onboarding process)
     * At the "My accounts" callback, ```accounts``` step name is sent to server side to be saved in ```user``` document
+    * __Save request__ format:
+        ```
+        PUT /register
+        {
+            "onboardedSteps": Array(String)
+        }
+        ```
 6. For the ```ending``` step:
     * User __authentication required__
     * Reachable via ```/onboarding/ending``` path
@@ -123,6 +164,13 @@ According to the ```user``` document properties:
         * If the ```activated``` is ```false``` AND ```onboardedSteps ``` is ```['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']``` => ```ending``` step
         * If the ```activated``` is ```true``` AND ```onboardedSteps ``` is ```['welcome', 'agreement', 'password', 'infos', 'accounts', 'ending']``` => cozy home
         * __Default__ => ```welcome``` step with ```onboardedSteps``` set to ```[]```
+    * __Save request__ format:
+        ```
+        PUT /register
+        {
+            "onboardedSteps": Array(String)
+        }
+        ```
 
 #### Handle onboarding changes
 

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -88,7 +88,7 @@ module.exports.saveUnauthenticatedUser = (req, res, next) ->
         if Object.keys(passwordValidationError).length
             dataErrors.password = localization.t 'password not valid'
     [
-        'allowStats',
+        'allow_stats',
         'isCGUaccepted',
         'onboardedSteps'
     ].forEach (property) =>
@@ -155,10 +155,10 @@ module.exports.saveAuthenticatedUser = (req, res, next) ->
         if requestData[property]
             userToSave[property] = requestData[property]
 
-    # if ending step done, user is registred
-    if requestData.stepSlug = "ending"
+    # if final step done, user is registred
+    if userToSave?.onboardedSteps is ONBOARDING_STEPS
         userToSave.activated = true
-    # onboarded steps update
+
     validationErrors = User.validate userToSave
 
     unless Object.keys(validationErrors).length

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -114,7 +114,7 @@ module.exports.saveUnauthenticatedUser = (req, res, next) ->
             else
                 Instance.createOrUpdate instanceData, (err) ->
                     return next new Error err if err
-                    User.createNew userData, (err) ->
+                    User.createNew userToSave, (err) ->
                         return next new Error err if err
 
                         # at first load, 'en' is the default locale

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -83,15 +83,15 @@ module.exports.saveUnauthenticatedUser = (req, res, next) ->
         hash = helpers.cryptPassword requestData.password
         userToSave.password = hash.hash
         userToSave.salt = hash.salt
-        passwdValidationError =
+        passwordValidationError =
             User.validatePassword requestData.password
-        if passwdValidationError
-            dataErrors.password = localization.t 'password too short'
+        if Object.keys(passwordValidationError).length
+            dataErrors.password = localization.t 'password not valid'
     [
         'allowStats',
-        'CGUaccepted',
+        'isCGUaccepted',
         'onboardedSteps'
-    ].forEach(property) =>
+    ].forEach (property) =>
         if requestData[property]
             userToSave[property] = requestData[property]
 
@@ -124,7 +124,7 @@ module.exports.saveUnauthenticatedUser = (req, res, next) ->
                         next()
     else
         error        = new Error 'Errors with data'
-        error.errors = errors
+        error.errors = dataErrors
         error.status = 400
         next error
 
@@ -151,7 +151,7 @@ module.exports.saveAuthenticatedUser = (req, res, next) ->
         'email',
         'timezone',
         'onboardedSteps'
-    ].forEach(property) =>
+    ].forEach (property) =>
         if requestData[property]
             userToSave[property] = requestData[property]
 

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -110,7 +110,7 @@ module.exports.saveUnauthenticatedUser = (req, res, next) ->
             else if users.length
                 users[0].merge userToSave, (err) ->
                     return next new Error err if err
-                    res.status(200).send('User data correctly updated')
+                    res.status(200).send(result: 'User data correctly updated')
             else
                 Instance.createOrUpdate instanceData, (err) ->
                     return next new Error err if err
@@ -120,7 +120,9 @@ module.exports.saveUnauthenticatedUser = (req, res, next) ->
                         # at first load, 'en' is the default locale
                         # we must change it now if it has changed
                         localization.setLocale requestData.locale
-                        res.status(201).send('User data correctly created')
+                        res.status(201).send(
+                            result: 'User data correctly created'
+                        )
     else
         error        = new Error 'Errors with data'
         error.errors = dataErrors
@@ -161,7 +163,7 @@ module.exports.saveAuthenticatedUser = (req, res, next) ->
             if users.length
                 users[0].merge userToSave, (err) ->
                     return next new Error err if err
-                    res.status(200).send('User data correctly updated')
+                    res.status(200).send(result: 'User data correctly updated')
             else
                 error        = new Error 'User document not found'
                 error.status = 404

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -15,8 +15,9 @@ module.exports =
     'routes/reset*': get: index.resetRoutes
 
     'register':
-        get: [utils.isNotAuthenticated, auth.registerIndex]
-        post: [auth.register, utils.authenticate]
+        get: [utils.isNotAuthenticated, auth.onboarding]
+        post: auth.saveUnauthenticatedUser
+        put: auth.saveAuthenticatedUser
 
     'login':
         get: [utils.isNotAuthenticated, auth.loginIndex]

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -17,7 +17,7 @@ module.exports =
     'register':
         get: [utils.isNotAuthenticated, auth.onboarding]
         post: [utils.isNotAuthenticated, auth.saveUnauthenticatedUser]
-        put: auth.saveAuthenticatedUser
+        put: [utils.isAuthenticated, auth.saveAuthenticatedUser]
 
     'login':
         get: [utils.isNotAuthenticated, auth.loginIndex]

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -16,7 +16,7 @@ module.exports =
 
     'register':
         get: [utils.isNotAuthenticated, auth.onboarding]
-        post: auth.saveUnauthenticatedUser
+        post: [utils.isNotAuthenticated, auth.saveUnauthenticatedUser]
         put: auth.saveAuthenticatedUser
 
     'login':

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -74,13 +74,23 @@ User.getUsername = (callback) ->
 
 
 User.validate = (data, errors = {}) ->
-    if not helpers.checkEmail data.email
+    if data.email and not helpers.checkEmail data.email
         errors.email = localization.t 'invalid email format'
 
-    if not (data.timezone in timezones)
+    if data.timezone and not (data.timezone in timezones)
         errors.timezone = localization.t 'invalid timezone'
 
     return errors
+
+
+User.checkInfos = (data) ->
+    hasEmail = if data.email then helpers.checkEmail(data.email) else false
+    hasUserName = data?.public_name
+    hasTimezone = if data.timezone
+        not timezones.indexOf(data.timezone) is -1
+    else
+        false
+    return hasEmail and hasUserName and hasTimezone
 
 
 User.validatePassword = (password, errors = {}) ->

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -63,16 +63,9 @@ User.getUsername = (callback) ->
     User.first (err, user) ->
         return callback err if err
 
-        return callback() unless user
+        return callback() unless user and user.public_name
 
-        username = if user.public_name?.length > 0
-            user.public_name
-        else
-            helpers.hideEmail user.email
-                .split ' '
-                .map (word) -> word[0].toUpperCase() + word.slice(1)
-                .join ' '
-        callback null, username
+        callback null, user.public_name
 
 
 User.validate = (data, errors = {}) ->

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -20,11 +20,13 @@ module.exports = User = cozydb.getModel 'User',
     timezone: String
     owner: Boolean
     allow_stats: Boolean
+    isCGUaccepted: Boolean
     activated: Boolean
     encryptedOtpKey: String
     hotpCounter: Number
     authType: String
     encryptedRecoveryCodes: Array
+    onboardedSteps: Array
 
 
 User.createNew = (data, callback) ->


### PR DESCRIPTION
Add documentation about user data management by the onboarding (.md file). This documentation describe the existing working and data flow.
A proposition is given to:
* [Detect the step according to the user document context](https://github.com/cozy/cozy-proxy/pull/309/files#diff-bafd0c87fdf0cc50bd63327c02fcecc1R75)
* [Describe views behaviours with data](https://github.com/cozy/cozy-proxy/pull/309/files#diff-bafd0c87fdf0cc50bd63327c02fcecc1R90)
* [Give a way to update onboarding steps in the future](https://github.com/cozy/cozy-proxy/pull/309/files#diff-bafd0c87fdf0cc50bd63327c02fcecc1R119)

__Important points:__
* ```welcome```, ```agreement``` and ```password``` steps are processing __before the login__, so the only one user data used is the ```public_name```.
    * Endpoint to use: ```POST /register```
* Other steps  will require user authentication to request other user informations from the user document (for pre filled features).
    * Endpoint to use: ```PUT /register```