### PR TITLE
Finalize Onboarding welcome step

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -50,29 +50,12 @@ class App extends Application
     # Initialize routes relative to onboarding step.
     # The idea is to configure the router externally as a "native"
     # Backbone Router
-    # @param steps a list of Step instance
-    initializeRouter: (steps) =>
+    initializeRouter: () =>
         @router = new Router app: @
         @router.route \
-            'register(?step=:step)',
+            'register(/:step)',
             'register',
-            (step) => @handleStepRoute(step)
-
-        steps.forEach (step) => @initializeStepRoute step
-
-
-    # Initialize one route only
-    # @param router Backbone.Router instance
-    # @param step Step instance
-    initializeStepRoute: (step) =>
-        StepView = require "./views/#{step.view}"
-        @router.route "#{step.route}", "route:#{step.route}", () =>
-            nextStep = @onboarding.getNextStep step
-            @layout.showChildView 'content',
-                new StepView
-                    model: new StepModel step: step, next: nextStep
-                    progression: new ProgressionModel \
-                        @onboarding.getProgression step
+            @handleRegisterRoute
 
 
     # Internal handler called when the onboarding's internal step has just
@@ -82,14 +65,25 @@ class App extends Application
         @router.navigate step.route, trigger: true
 
 
-    # Register is the default main route for Onboarding
-    handleStepRoute: (stepName='preset') ->
+    # Handler for register route, display onboarding's current step
+    handleRegisterRoute: =>
         # Load onboarding stylesheet
         AppStyles = require './styles/onboarding.styl'
 
-        step = @onboarding.getStepByName stepName
-        throw new Error 'Step does not exist' unless step
-        @onboarding.goToStep @onboarding.getStepByName stepName
+        currentStep = @onboarding.getCurrentStep()
+        @router.navigate currentStep.route
+        @showStep(currentStep)
+
+
+    # Load the view for the given step
+    showStep: (step) ->
+        StepView = require "./views/#{step.view}"
+        nextStep = @onboarding.getNextStep step
+        @layout.showChildView 'content',
+            new StepView
+                model: new StepModel step: step, next: nextStep
+                progression: new ProgressionModel \
+                    @onboarding.getProgression step
 
 
 # Exports Application singleton instance

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -29,7 +29,8 @@ class App extends Application
         @on 'start', =>
 
             user = {
-                username: ENV.username
+                username: ENV.username,
+                hasInfos: ENV.hasInfos
             }
 
             @onboarding = new Onboarding(user, steps)

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -30,13 +30,13 @@ class App extends Application
 
             user = {
                 username: ENV.username,
-                hasInfos: ENV.hasInfos
+                hasValidInfos: ENV.hasValidInfos
             }
 
-            @onboarding = new Onboarding(user, steps)
+            @onboarding = new Onboarding(user, steps, ENV.currentStep)
             @onboarding.onStepChanged (step) => @handleStepChanged(step)
 
-            @initializeRouter @onboarding.steps
+            @initializeRouter()
 
             @layout = new AppLayout()
             @layout.render()

--- a/client/app/config/steps/accounts.coffee
+++ b/client/app/config/steps/accounts.coffee
@@ -1,5 +1,5 @@
 module.exports = {
     name: 'accounts',
-    route: 'accounts',
+    route: 'register/accounts',
     view: 'steps/accounts'
 }

--- a/client/app/config/steps/agreement.coffee
+++ b/client/app/config/steps/agreement.coffee
@@ -1,5 +1,5 @@
 module.exports = {
     name: 'agreement',
-    route: 'agreement',
+    route: 'register/agreement',
     view : 'steps/agreement'
 }

--- a/client/app/config/steps/all.coffee
+++ b/client/app/config/steps/all.coffee
@@ -3,16 +3,16 @@
 # At this time there is only proper
 welcome = require './welcome'
 agreement = require './agreement'
-infos = require './infos'
 password = require './password'
+infos = require './infos'
 accounts = require './accounts'
 confirmation = require './confirmation'
 
 module.exports = [
     welcome,
     agreement,
-    infos,
     password,
+    infos,
     accounts,
     confirmation
 ]

--- a/client/app/config/steps/confirmation.coffee
+++ b/client/app/config/steps/confirmation.coffee
@@ -1,5 +1,5 @@
 module.exports = {
     name: 'confirmation',
-    route: 'confirmation',
+    route: 'register/confirmation',
     view : 'steps/confirmation'
 }

--- a/client/app/config/steps/infos.coffee
+++ b/client/app/config/steps/infos.coffee
@@ -1,6 +1,6 @@
 module.exports = {
     name: 'infos',
-    route: 'infos',
+    route: 'register/infos',
     view : 'steps/infos',
     isActive: (user) ->
         return not user.hasValidInfos

--- a/client/app/config/steps/infos.coffee
+++ b/client/app/config/steps/infos.coffee
@@ -3,5 +3,5 @@ module.exports = {
     route: 'infos',
     view : 'steps/infos',
     isActive: (user) ->
-        return not user.hasInfos
+        return not user.hasValidInfos
 }

--- a/client/app/config/steps/infos.coffee
+++ b/client/app/config/steps/infos.coffee
@@ -1,16 +1,7 @@
-timezones = require '../../lib/timezones'
-EmailHelper = require '../../lib/email_helper'
-
-isValidTimezone = (timezone) ->
-    return timezone? and not(timezones.indexOf(timezone) is -1)
-
-isValidEmail = (email) ->
-    return email? and EmailHelper.check(email)
-
 module.exports = {
     name: 'infos',
     route: 'infos',
     view : 'steps/infos',
     isActive: (user) ->
-        return not (isValidTimezone(user.timezone) and isValidEmail(user.email))
+        return not user.hasInfos
 }

--- a/client/app/config/steps/password.coffee
+++ b/client/app/config/steps/password.coffee
@@ -2,7 +2,7 @@ jQuery = require 'jquery'
 
 module.exports = {
     name: 'password',
-    route: 'password',
+    route: 'register/password',
     view : 'steps/password'
 
     # If OK, return null

--- a/client/app/config/steps/password.coffee
+++ b/client/app/config/steps/password.coffee
@@ -10,7 +10,13 @@ module.exports = {
     validate: (data) ->
         return null
 
-    submit: (data) ->
+    save: (data) ->
         data = JSON.stringify data
-        jQuery.post('/register', data)
+        return new Promise((resolve, reject) ->
+            jQuery.post({
+                url: '/register'
+                data: data
+                success: resolve
+                error: reject
+            })).then @handleSaveSuccess, @handleSaveError
 }

--- a/client/app/config/steps/welcome.coffee
+++ b/client/app/config/steps/welcome.coffee
@@ -1,12 +1,6 @@
-handleSaveSuccess = () ->
-    console.debug 'success'
-
-handleSaveError = () ->
-    throw new Error 'Error occured during save'
-
 module.exports = {
-    name: 'preset', # named 'preset' to match existing codebase.
-    route: 'welcome',
+    name: 'welcome',
+    route: 'register/welcome',
     view: 'steps/welcome',
     save: (data) ->
         return fetch '/register',

--- a/client/app/config/steps/welcome.coffee
+++ b/client/app/config/steps/welcome.coffee
@@ -1,5 +1,16 @@
+handleSaveSuccess = () ->
+    console.debug 'success'
+
+handleSaveError = () ->
+    throw new Error 'Error occured during save'
+
 module.exports = {
     name: 'preset', # named 'preset' to match existing codebase.
     route: 'welcome',
-    view : 'steps/welcome'
+    view: 'steps/welcome',
+    save: (data) ->
+        return fetch '/register',
+            method: 'POST',
+            body: JSON.stringify {onboardedSteps: ['welcome']}
+        .then @handleSaveSuccess, @handleSaveError
 }

--- a/client/app/lib/email_helper.coffee
+++ b/client/app/lib/email_helper.coffee
@@ -1,6 +1,0 @@
-# Check validity of an email. Borrowed from server/lib/helpers.coffee
-module.exports.check = (email) ->
-    # coffeelint: disable=max_line_length
-    re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-    # coffeelint: enable=max_line_length
-    return email? and email.length > 0 and re.test(email)

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -11,20 +11,10 @@ class Step
           'isActive',
           'fetchUser',
           'validate',
-          'submit'
+          'save'
         ].forEach (property) =>
             if step[property]?
-
-                # Do not override submit
-                # such as @submit that allow to goto next step
-                # @submit mussnt be overidden but @isActive yes
-                if property is 'submit'
-                    nativeCallback = @[property]
-                    @[property] = (args...) =>
-                        step[property].call @, args...
-                        nativeCallback.call @, args...
-                else
-                    @[property] = step[property]
+                @[property] = step[property]
 
         @fetchUser user
 
@@ -60,13 +50,40 @@ class Step
     isActive: (user) ->
         return true
 
+
     # Submit the step
     # This method should be overriden by step given as parameter to add
     # for example a validation step.
     # Maybe it should return a Promise or a call a callback couple
     # in the near future
-    submit: () ->
-        @triggerCompleted()
+    submit: (data={}) ->
+        return @save data
+        .then @handleSubmitSuccess, @handleSubmitError
+
+
+    # Handler for error occuring during a submit()
+    handleSubmitError: (error) =>
+        throw new Error 'Unable to save step information'
+
+
+    # Handler for submit success
+    handleSubmitSuccess: => @triggerCompleted()
+
+
+    # Save data
+    # By default this method returns a resolved promise, but it can overriden
+    # by specifying another save method in constructor parameters
+    # @param data : JS object containing data to save
+    save: (data={}) ->
+        return Promise.resolve(data)
+
+    # Success handler for save() call
+    handleSaveSuccess: (data) =>
+        return data
+
+    # Error handler for save() call
+    handleSaveError: =>
+        throw new Error 'Error occured during save'
 
 
 # Main class
@@ -78,7 +95,7 @@ module.exports = class Onboarding
         @initialize user, steps
 
 
-    initialize: (user, steps) ->
+    initialize: (user, steps, options) ->
         throw new Error 'Missing mandatory `steps` parameter' unless steps
 
         @user = user
@@ -90,7 +107,6 @@ module.exports = class Onboarding
                     stepModel.onCompleted @handleStepCompleted
                 return activeSteps
             , []
-
 
     # Records handler for 'stepChanged' pseudo-event, triggered when
     # the internal current step in onboarding has changed.

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -91,11 +91,11 @@ class Step
 module.exports = class Onboarding
 
 
-    constructor: (user, steps) ->
-        @initialize user, steps
+    constructor: (user, steps, currentStepName) ->
+        @initialize user, steps, currentStepName
 
 
-    initialize: (user, steps, options) ->
+    initialize: (user, steps, currentStepName) ->
         throw new Error 'Missing mandatory `steps` parameter' unless steps
 
         @user = user
@@ -107,6 +107,12 @@ module.exports = class Onboarding
                     stepModel.onCompleted @handleStepCompleted
                 return activeSteps
             , []
+
+        if currentStepName
+            @currentStep = @getStepByName currentStepName
+            if not @currentStep
+                throw new Error 'Given current step does not exist in step list'
+
 
     # Records handler for 'stepChanged' pseudo-event, triggered when
     # the internal current step in onboarding has changed.
@@ -192,6 +198,10 @@ module.exports = class Onboarding
             return null
 
         return @steps[nextStepIndex]
+
+
+    getCurrentStep: () =>
+        return @currentStep
 
 
 # Step is exposed for test purposes only

--- a/client/doc/onboarding.md
+++ b/client/doc/onboarding.md
@@ -140,6 +140,11 @@ console.log(step.useremail);
 Returns true if the step has to be active for the given `user`. Returns `true` by default.
 This method can be overriden by specifying an `isActive` method in constructor parameter.
 
+#### save(data)
+* `data`: Data to send to the server
+
+This method returns by default a resolved Promise. This method may be overriden in a step object config. To work, it just needs to return a Promise.
+
 ##### Example
 ```javascript
 let step = new Step({

--- a/client/doc/onboarding.md
+++ b/client/doc/onboarding.md
@@ -23,7 +23,12 @@ Howerver, it will be possible to override class methods in config objects (not i
 
 ## Methods
 ### Onboarding
-#### initialize(user, steps)
+#### initialize(user, steps, currentStepName)
+#### parameters
+* `user`: JS object representing user's properties
+* `steps`: Array of JS object representing steps
+* `currentStepName`: String reprensenting the current (or first) step in onboarding.
+
 Set the user and the steps list for the current onboarding.
 Called by the constructor method.
 The steps list should look like :
@@ -98,6 +103,10 @@ progression will be
     labels: ['example1', 'example2']
 }
 ```
+
+#### getCurrentStep()
+
+Returns onboarding's current step.
 
 ### Step
 

--- a/client/test/config/steps/infos.js
+++ b/client/test/config/steps/infos.js
@@ -5,10 +5,10 @@ let infos = require('../../../app/config/steps/infos.coffee');
 
 describe('Step: infos', () => {
     describe('#isActive', () => {
-        it('should return true for user.hasInfos is false', () => {
+        it('should return true for user.hasValidInfos is false', () => {
             // arrange
             let user = {
-                hasInfos: false
+                hasValidInfos: false
             };
 
             // act
@@ -18,10 +18,10 @@ describe('Step: infos', () => {
             assert.isTrue(result);
         });
 
-        it('should return false for user.hasInfos is true', () => {
+        it('should return false for user.hasValidInfos is true', () => {
             // arrange
             let user = {
-                hasInfos: true
+                hasValidInfos: true
             };
 
             // act

--- a/client/test/config/steps/infos.js
+++ b/client/test/config/steps/infos.js
@@ -5,11 +5,10 @@ let infos = require('../../../app/config/steps/infos.coffee');
 
 describe('Step: infos', () => {
     describe('#isActive', () => {
-        it('should return true for user with invalid email', () => {
+        it('should return true for user.hasInfos is false', () => {
             // arrange
             let user = {
-                email: '',
-                timezone: 'Europe/Paris'
+                hasInfos: false
             };
 
             // act
@@ -19,25 +18,10 @@ describe('Step: infos', () => {
             assert.isTrue(result);
         });
 
-        it('should return true for user with invalid timezone', () => {
+        it('should return false for user.hasInfos is true', () => {
             // arrange
             let user = {
-                email: 'claude@example.org',
-                timezone: 'not a timezone'
-            };
-
-            // act
-            let result = infos.isActive(user);
-
-            // assert
-            assert.isTrue(result);
-        });
-
-        it('should return false for user with valid email and timezone', () => {
-            // arrange
-            let user = {
-                email: 'claude@example.org',
-                timezone: 'Europe/Paris'
+                hasInfos: true
             };
 
             // act

--- a/client/test/config/steps/password.js
+++ b/client/test/config/steps/password.js
@@ -41,18 +41,24 @@ describe('Step: password', () => {
     });
 
 
-    describe('#submit', () => {
+    describe('#save', () => {
 
         it('should send POST request', () => {
             // Define global.jQUery
             // so that configPassword could use it
-            global.jQuery.post = sinon.spy()
+            sinon.stub(global.jQuery, 'post');
             let data = { email: '', password: 'plop', timezone: TimeZones[0]}
-            PasswordConfig.submit(data);
+            PasswordConfig.save(data);
 
             data = JSON.stringify(data);
+
+            let spyArgument = global.jQuery.post.getCalls(0)[0].args[0];
+
             assert(global.jQuery.post.calledOnce);
-            assert(global.jQuery.post.calledWith('/register', data));
+            assert.equal('/register', spyArgument.url);
+            assert.deepEqual(data, spyArgument.data);
+
+            global.jQuery.post.restore();
         });
 
     });

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -95,7 +95,6 @@ describe('Onboarding', () => {
 
         it('should not map inActive steps', () => {
             // arrange
-            // arrange
             let user = null;
             let steps = [{
                 name: 'test',
@@ -118,6 +117,51 @@ describe('Onboarding', () => {
             assert.equal('test', step1.name);
             assert.equal('testroute', step1.route);
             assert.equal('testview', step1.view);
+        });
+
+        it('should set current step', () => {
+            // arrange
+            let user = null;
+            let steps = [{
+                name: 'test',
+                route: 'testroute',
+                view: 'testview'
+            }, {
+                name: 'test2',
+                route: 'testroute2',
+                view: 'testview2'
+            }];
+
+            let step2Name = 'test2'
+
+            // act
+            let onboarding = new Onboarding(user, steps, step2Name);
+            let step2 = onboarding.getStepByName(step2Name);
+
+            // assert
+            assert.deepEqual(step2, onboarding.currentStep)
+        });
+
+        it('should throw an error if given current step does not exist', () => {
+            // arrange
+            let user = null;
+            let steps = [{
+                name: 'test',
+                route: 'testroute',
+                view: 'testview'
+            }, {
+                name: 'test2',
+                route: 'testroute2',
+                view: 'testview2'
+            }];
+
+            let fn = () => {
+                // act
+                let onboarding = new Onboarding(user, steps, 'test3');
+            };
+
+            // assert
+            assert.throw(fn, 'Given current step does not exist in step list');
         });
     });
 

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -834,32 +834,18 @@ describe('Onboarding.Step', () => {
 
 
     describe('#submit', () => {
-
-        it('should call triggerCompleted (default #submit)', () => {
+        it('should call save', () => {
             // arrange
             let step = new Step();
-            step.triggerCompleted = sinon.spy();
+            let savePromise = Promise.resolve();
+            let promiseStub = sinon.stub(step, 'save');
+            promiseStub.returns(savePromise);
 
             // act
             step.submit();
 
             // assert
-            assert(step.triggerCompleted.calledOnce);
-        });
-
-
-        it('should call triggerCompleted (overriden #submit)', () => {
-            // arrange
-            let configSubmit = sinon.spy();
-            let step = new Step({ submit: configSubmit });
-            step.triggerCompleted = sinon.spy();
-
-            // act
-            step.submit();
-
-            // assert
-            assert(configSubmit.calledOnce);
-            assert(step.triggerCompleted.calledOnce);
+            assert(step.save.calledOnce);
         });
     });
 

--- a/client/test/stories/onboarding.js
+++ b/client/test/stories/onboarding.js
@@ -22,23 +22,35 @@ describe('Password Stories', () => {
     describe('Add a password', () => {
 
         beforeEach(() => {
-            // Select 1rst step
-            currentIndex = 3;
-            onboarding.goToStep(onboarding.steps[currentIndex]);
+            const jsdom = require('jsdom-global')();
+            global.jQuery = require('jquery');
+
+            // Select password step
+            onboarding.goToStep(onboarding.getStepByName('password'));
         });
 
 
-        it('should go to `nextStep` when password is OK', () => {
-            const passwordStep = onboarding.steps[currentIndex];
-            const nextStep = onboarding.steps[currentIndex + 1];
+        it('should go to `nextStep` when password is OK', (done) => {
+            const passwordStep = onboarding.getStepByName('password');
+            const passwordStepIndex = onboarding.steps.indexOf(passwordStep);
+            const nextStep = onboarding.steps[passwordStepIndex+1];
+
+            sinon.stub(global.jQuery, 'post');
+            global.jQuery.post.yieldsTo('success');
 
             // Select StepPassword
             onboarding.goToStep(passwordStep);
-            assert.deepEqual(passwordStep, onboarding.currentStep)
 
             // Submit password value
             passwordStep.submit({ password: 'toto' })
-            assert.deepEqual(nextStep, onboarding.currentStep)
+
+            // Deal with async Promise call
+            setTimeout(() => {
+                assert.deepEqual(onboarding.getCurrentStep(), nextStep);
+                global.jQuery.post.restore();
+                done()
+            }, 10);
+
         });
 
 

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -10,16 +10,6 @@ localization = require '../lib/localization_manager'
 passwordKeys = require '../lib/password_keys'
 otpManager   = require '../lib/2fa_manager'
 
-# hardcoded onboarding steps order and slug names
-ONBOARDING_STEPS = [
-    'welcome',
-    'agreement',
-    'password',
-    'infos',
-    'accounts',
-    'ending'
-]
-
 
 getEnv = (callback) ->
     User.getUsername (err, username) ->
@@ -34,14 +24,6 @@ getEnv = (callback) ->
                 apps:     Object.keys require('../lib/router').getRoutes()
 
             callback null, env
-
-# Return the expected onboarding step for given userData
-getCurrentOnboardingStep = (userData) ->
-    return ONBOARDING_STEPS[0] unless userData and userData.onboardedSteps
-
-    return ONBOARDING_STEPS.find (step) ->
-        return userData.onboardedSteps.indexOf(step) is -1
-
 
 module.exports.onboarding = (req, res, next) ->
     getEnv (err, env) ->
@@ -60,7 +42,7 @@ module.exports.onboarding = (req, res, next) ->
                     next error
 
                 # According to steps changes
-                if userData?.onboardedSteps is ONBOARDING_STEPS
+                if User.isRegistered userData
                     res.redirect '/login'
                 else
                     if userData
@@ -71,7 +53,7 @@ module.exports.onboarding = (req, res, next) ->
                     # registration mode
                     # TODO: this one is temporary, and need to be removed
                     # when we merge CSS again.
-                    env.currentStep = getCurrentOnboardingStep userData
+                    env.currentStep = User.getCurrentOnboardingStep userData
                     res.render 'index', {env: env, onboarding: true}
 
 
@@ -160,7 +142,7 @@ module.exports.saveAuthenticatedUser = (req, res, next) ->
             userToSave[property] = requestData[property]
 
     # if final step done, user is registred
-    if userToSave?.onboardedSteps is ONBOARDING_STEPS
+    if User.isRegistered userToSave
         userToSave.activated = true
 
     validationErrors = User.validate userToSave
@@ -189,9 +171,19 @@ module.exports.loginIndex = (req, res, next) ->
         if err
             next new Error err
         else
-            return res.redirect '/register'
-            res.set 'X-Cozy-Login-Page', 'true'
-            res.render 'index', env: env
+            # get user data
+            User.first (err, userData) ->
+                if err
+                    error = new Error "[Error to access cozy user] #{err.code}"
+                    error.status   = 500
+                    error.template = name: 'error'
+                    next error
+
+                if not User.isRegistered userData
+                    return res.redirect '/register'
+
+                res.set 'X-Cozy-Login-Page', 'true'
+                res.render 'index', env: env
 
 
 module.exports.forgotPassword = (req, res, next) ->

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -189,7 +189,7 @@ module.exports.loginIndex = (req, res, next) ->
         if err
             next new Error err
         else
-            return res.redirect '/register' unless env.username
+            return res.redirect '/register'
             res.set 'X-Cozy-Login-Page', 'true'
             res.render 'index', env: env
 

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -35,6 +35,13 @@ getEnv = (callback) ->
 
             callback null, env
 
+# Return the expected onboarding step for given userData
+getCurrentOnboardingStep = (userData) ->
+    return ONBOARDING_STEPS[0] unless userData and userData.onboardedSteps
+
+    return ONBOARDING_STEPS.find (step) ->
+        return userData.onboardedSteps.indexOf(step) is -1
+
 
 module.exports.onboarding = (req, res, next) ->
     getEnv (err, env) ->
@@ -64,7 +71,8 @@ module.exports.onboarding = (req, res, next) ->
                     # registration mode
                     # TODO: this one is temporary, and need to be removed
                     # when we merge CSS again.
-                    res.render 'index', {env: env, onBoarding: true}
+                    env.currentStep = getCurrentOnboardingStep userData
+                    res.render 'index', {env: env, onboarding: true}
 
 
 # Save unauthenticated user document (only if password doesn't exist)

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -14,6 +14,9 @@ module.exports =
     'routes': get: index.showRoutes
     'routes/reset*': get: index.resetRoutes
 
+    'register/:step':
+        get: [utils.isNotAuthenticated, auth.onboarding]
+
     'register':
         get: [utils.isNotAuthenticated, auth.onboarding]
         post: [utils.isNotAuthenticated, auth.saveUnauthenticatedUser]

--- a/server/lib/array_helper.coffee
+++ b/server/lib/array_helper.coffee
@@ -1,0 +1,9 @@
+# Compares who array and returns true if they contains the same elements
+module.exports.areEquals = (array1, array2) ->
+    if not (array1 and array2)
+        return false
+    if array1.length isnt array2.length
+        return false
+    else
+        isElementsEqual = array1.every (elem, i) -> elem is array2[i]
+        return isElementsEqual

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -94,7 +94,7 @@ User.checkInfos = (data) ->
     hasEmail = if data.email then helpers.checkEmail(data.email) else false
     hasUserName = data?.public_name
     hasTimezone = if data.timezone
-        not timezones.indexOf(data.timezone) is -1
+        not (timezones.indexOf(data.timezone) is -1)
     else
         false
     return hasEmail and hasUserName and hasTimezone

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -5,12 +5,22 @@ urlHelper = require 'cozy-url-sdk'
 helpers      = require '../lib/helpers'
 timezones    = require '../lib/timezones'
 localization = require '../lib/localization_manager'
-
+ArrayHelper = require '../lib/array_helper'
 
 client = new Client urlHelper.dataSystem.url()
 if process.env.NODE_ENV in ['production', 'test']
     client.setBasicAuth process.env.NAME, process.env.TOKEN
 
+# hardcoded onboarding steps order and slug names
+# TODO: find a way to define those step only server side or only client site.
+ONBOARDING_STEPS = [
+    'welcome',
+    'agreement',
+    'password',
+    'infos',
+    'accounts',
+    'ending'
+]
 
 fixOnboardedSteps = (user) ->
     user.onboardedSteps = user.onboardedSteps or []
@@ -105,3 +115,16 @@ User.validatePassword = (password, errors = {}) ->
         errors.password = localization.t 'password too short'
 
     return errors
+
+# Return the expected onboarding step for given userData
+User.getCurrentOnboardingStep = (userData) ->
+    return ONBOARDING_STEPS[0] unless userData and userData.onboardedSteps
+
+    return ONBOARDING_STEPS.find (step) ->
+        return userData.onboardedSteps.indexOf(step) is -1
+
+# Returns true if user is complete and is ready to log into his Cozy.
+# At this time this memthod check only if the user has completed all onboarding
+# steps.
+User.isRegistered = (userData) ->
+    return ArrayHelper.areEquals userData?.onboardedSteps, ONBOARDING_STEPS

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -12,6 +12,16 @@ if process.env.NODE_ENV in ['production', 'test']
     client.setBasicAuth process.env.NAME, process.env.TOKEN
 
 
+fixOnboardedSteps = (user) ->
+    user.onboardedSteps = user.onboardedSteps or []
+    # It seems that there is a bug, string Arrays are fetched like following:
+    # [['text']] instead of ['text']
+    # So until it's fixed, we prevent this issue by mapping the desired values
+    # it the first array object is an array.
+    if Array.isArray user.onboardedSteps[0]
+        user.onboardedSteps = user.onboardedSteps[0]
+    return user
+
 module.exports = User = cozydb.getModel 'User',
     email: String
     password: String
@@ -56,7 +66,9 @@ User.first = (callback) ->
     User.request 'all', (err, users) ->
         if err then callback err
         else if not users or users.length is 0 then callback null, null
-        else  callback null, users[0]
+        else
+            user = fixOnboardedSteps users[0]
+            callback null, user
 
 
 User.getUsername = (callback) ->

--- a/server/views/layouts/_base.jade
+++ b/server/views/layouts/_base.jade
@@ -28,7 +28,7 @@ html(lang=getLocale().language)
 
     link(rel="stylesheet", href="/fonts/fonts.css")
     link(rel="stylesheet", href="/common#{hash}.css")
-    link(rel="stylesheet", href="/#{onBoarding?'onboarding':'app'}#{hash}.css")
+    link(rel="stylesheet", href="/#{onboarding?'onboarding':'app'}#{hash}.css")
 
     block js
 


### PR DESCRIPTION
Thanks @CPatchane to have a review.

This PR is a little bit huge but it was hard to split it in several parts afterwhile. So sorry about that.

It essentially does :

* Fix somme little typos or issues server-side detected during integration
* Add a `save()` method to steps to be able to save content each time a step is completed. It also add related docs.
* Finally, it fixes and simplifies routes management :
  * Synchronizes server and client (this last one was too complex)
  * Makes serveral changes into `Application`
  * User is no more redirected to login page when an username exists in DB
  * In client `Application` every `register` route is now handled by a single method that shows onboarding's current step.

### Technical debt :
To save its data, the welcome step uses `fetch()`, but no polyfill is provided. This can be done with webpack. Also, I encountered difficulties to test this method, so no test is provided at this time.