### PR TITLE
Change next property in view to string

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -90,9 +90,10 @@ class App extends Application
     showStep: (step, err=null) ->
         StepView = require "./views/#{step.view}"
         nextStep = @onboarding.getNextStep step
+        next = nextStep?.route or @onboardingSuccessRedirect
         @layout.showChildView 'content',
             new StepView
-                model: new StepModel step: step, next: nextStep
+                model: new StepModel step: step, next: next
                 error: err
                 progression: new ProgressionModel \
                     @onboarding.getProgression step

--- a/client/app/views/templates/view_steps_welcome.jade
+++ b/client/app/views/templates/view_steps_welcome.jade
@@ -12,4 +12,4 @@ block region
     p= t('step welcome congrats')
 
 block controls
-    a(href=next.route role="button" class="next")= t('step welcome next')
+    a(href=next role="button" class="next")= t('step welcome next')


### PR DESCRIPTION
It will allow us to pass another an agnostic value, i.e. a simple route which is not related to a step. For example, to redirect to Google Import at the end of onboarding process.