### PR TITLE
Fix "ghost user" behaviour

### DIFF
--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -105,10 +105,11 @@ class Step
 
     # Error handler for save() call
     handleSaveError: (err) =>
-        if not Object.keys(err.errors)
-            throw new Error err.error
-        else
+        if err.errors and Object.keys(err.errors)
             throw new Error @_joinValues(err.errors, '\n')
+        else
+            throw new Error err.error
+
 
 
 

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -74,7 +74,6 @@ module.exports.onboarding = (req, res, next) ->
 # DB. User is still authenticated but does not exist anymore in DB. As it is
 # not an expected state in production, we return a 403 forbidden error.
 module.exports.disallowAuthenticatedUser = (req, res, next) ->
-    console.log req.isAuthenticated()
     if req.isAuthenticated()
         res.status(403).send error: 'Not allowed to access this \
             enpoint while being authentified'

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -67,6 +67,21 @@ module.exports.onboarding = (req, res, next) ->
                     res.render 'index', {env: env, onboarding: true}
 
 
+# Disallow authenticated user
+# Some endpoints, mainly those called by first onboarding steps with post
+# method are not expecting an authentified user. But the situation could happen
+# when developing and after a user authentication followed by user deletion in
+# DB. User is still authenticated but does not exist anymore in DB. As it is
+# not an expected state in production, we return a 403 forbidden error.
+module.exports.disallowAuthenticatedUser = (req, res, next) ->
+    console.log req.isAuthenticated()
+    if req.isAuthenticated()
+        res.status(403).send error: 'Not allowed to access this \
+            enpoint while being authentified'
+    else
+        next()
+
+
 # Save unauthenticated user document (only if password doesn't exist)
 # Expected request body format (? means optionnal)
 # ?password

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -16,7 +16,7 @@ module.exports =
 
     'register/password':
         post: [
-            utils.isNotAuthenticated,
+            auth.disallowAuthenticatedUser,
             auth.saveUnauthenticatedUser,
             # Transparently authenticate the user after a setting the password
             utils.authenticate
@@ -27,7 +27,7 @@ module.exports =
 
     'register':
         get: [utils.isNotRegistered, auth.onboarding]
-        post: [utils.isNotAuthenticated, auth.saveUnauthenticatedUser]
+        post: [auth.disallowAuthenticatedUser, auth.saveUnauthenticatedUser]
         put: [
             utils.isAuthenticated,
             utils.isNotRegistered,


### PR DESCRIPTION
During tests and development sessions, it may happen that a user is authentified in the onboarding process (after filling his password), but does not exists anymore in DB (after a manual removal). In this precise situation, it is not possible anymore to save user's password during the password step.

To avoid that, we decided to throw an error, as this state is not exepcted in a production environment, and could trigger other unexpected error during the onboarding process.