### PR TITLE
Add access to MyAccounts after Accounts onboarding step

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -109,7 +109,7 @@ class App extends Application
                 @onboarding.getProgression step
 
         if step.name is @accountsStepName
-            stepView.on 'browse:myaccounts', @handleBrowseMyAccount
+            stepView.on 'browse:myaccounts', @handleBrowseMyAccounts
 
         @layout.showChildView 'content', stepView
 
@@ -117,7 +117,7 @@ class App extends Application
     # Handler when browse action is submited from the Accounts step view.
     # This handler show a dedicated view that encapsulate an iframe loading
     # MyAccounts application.
-    handleBrowseMyAccount: (stepModel) =>
+    handleBrowseMyAccounts: (stepModel) =>
         MyAccountsView = require './views/register/my_accounts'
         view = new MyAccountsView
             model: stepModel

--- a/client/app/styles/onboarding.styl
+++ b/client/app/styles/onboarding.styl
@@ -234,3 +234,9 @@ footer
         // mark upcoming items in grey
         &[aria-selected=true] ~ li
             background-color  $grey-02
+
+
+// MY ACCOUNTS IFRAME
+.my-accounts-container
+    flex-grow 1
+    border-width 0

--- a/client/app/styles/onboarding.styl
+++ b/client/app/styles/onboarding.styl
@@ -7,12 +7,16 @@
 
 // LAYOUTS
 [role=application]
-    display      flex
     min-height   100vh
     font-family  'Source Sans Pro', sans-serif
 
+// div inserted magically by Marionnette
+main > div
+    display      flex
+    min-height   100vh
 
-main
+
+.step-wrapper
     flex       0 1 30em
     margin     auto
     padding    1em

--- a/client/app/views/register/my_accounts.coffee
+++ b/client/app/views/register/my_accounts.coffee
@@ -1,0 +1,15 @@
+{LayoutView} = require 'backbone.marionette'
+
+module.exports = class MyAccountsView extends LayoutView
+    template: require '../templates/my_accounts'
+
+
+    initialize: (options) ->
+        super options
+        @myAccountsUrl = options.myAccountsUrl
+
+
+    serializeData: ->
+        data = super()
+        data.myAccountsUrl = @myAccountsUrl
+        return data

--- a/client/app/views/steps/accounts.coffee
+++ b/client/app/views/steps/accounts.coffee
@@ -23,7 +23,7 @@ module.exports = class AccountsView extends StepView
 
     onSubmit: (event)->
         event.preventDefault()
-        @model.submit()
+        @triggerMethod 'browse:myaccounts', @model
 
 
     serializeData: ->

--- a/client/app/views/templates/_view_step_base.jade
+++ b/client/app/views/templates/_view_step_base.jade
@@ -1,21 +1,22 @@
-header
-    figure(id=id)
-        if link
-            a(href=link target="_blank")
-                svg: use(xlink:href=figureid)
-        else
-            .svg-wrapper
-                svg: use(xlink:href=figureid)
+.step-wrapper
+    header
+        figure(id=id)
+            if link
+                a(href=link target="_blank")
+                    svg: use(xlink:href=figureid)
+            else
+                .svg-wrapper
+                    svg: use(xlink:href=figureid)
 
-    block header
+        block header
 
-form
-    div(role="region")
-        block region
+    form
+        div(role="region")
+            block region
 
 
-    footer
-        .controls
-            block controls
+        footer
+            .controls
+                block controls
 
-        .progression
+            .progression

--- a/client/app/views/templates/my_accounts.jade
+++ b/client/app/views/templates/my_accounts.jade
@@ -1,0 +1,1 @@
+iframe.my-accounts-container(src=myAccountsUrl)

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -22,6 +22,8 @@ getEnv = (callback) ->
                 username: username
                 otp:      !!otp
                 apps:     Object.keys require('../lib/router').getRoutes()
+                myAccountsUrl: process.env.COZY_MYACCOUNTS_URL \
+                    or '/app/konnectors/'
 
             callback null, env
 

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -23,7 +23,7 @@ getEnv = (callback) ->
                 otp:      !!otp
                 apps:     Object.keys require('../lib/router').getRoutes()
                 myAccountsUrl: process.env.COZY_MYACCOUNTS_URL \
-                    or '/app/konnectors/'
+                    or '/apps/konnectors/'
 
             callback null, env
 


### PR DESCRIPTION
Thanks to have a review @CPatchane

In this PR :

### Use of COZY_MYACCOUNTS_URL environment variable ###

If this environment variable is set, cozy-proxy use it as MyAccounts URL. Set to `/app/konnectors` by default. This variable will allow us to efficiently test locally during development and test, without dealing with URL management headache. Just run cozy-proxy with this command :
```terminal
$> PORT=9555 COZY_MYACCOUNTS_URL="http://localhost:9358" npm run watch
```

### Improve base view ###
To easily allow a full-screen iframe without using a dirty `position: absolute` (ping @m4dz), the base view has been a little bit revamped to have its `<main />` element now using the full width and height of the viewport. Its previous CSS properties has been reported into a dedicated `.step-wrapper` element. Side effect : agreement and infos views are upside down but we don't care for now.

### Use a new Marionette view for MyAccounts iframe ###
Instead of a hackish tweak in the Accounts step view for switching to MyAccounts, I prefered to use a brand new Marionnette View. I used Marionnette's clever event bubbling mechanism to make the Application listening to the Accounts view and show the MyAccounts iframe when needed.


### Using elegant flexbox to display the iframe in full-size ###
It speaks by itself. Have a look at the CSS. It's so beautiful. Poke @m4dz.