### PR TITLE
Better code split between onboarding an login/reset views

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -48,11 +48,10 @@ class App extends Application
     initializeRouter: () =>
         @router = new Router app: @
         # if onboarding, the pathname will be '/register*'
-        if window.location.pathname.indexOf('/register') is 0
-            @router.route \
-                'register(/:step)',
-                'register',
-                @initializeOnboarding
+        @router.route \
+            'register(/:step)',
+            'register',
+            @handleRegisterRoute
 
 
     # Internal handler called when the onboarding's internal step has just
@@ -77,11 +76,8 @@ class App extends Application
             @showStep step, err.message
 
 
-    # Handler for register route, display onboarding's current step
-    initializeOnboarding: =>
-        # Load onboarding stylesheet
-        AppStyles = require './styles/onboarding.styl'
-        # onboarding steps config
+    # Initialize the onboarding component
+    initializeOnboarding: ->
         steps = require './config/steps/all'
 
         user = {
@@ -89,10 +85,20 @@ class App extends Application
             hasValidInfos: ENV.hasValidInfos
         }
 
-        @onboarding = new Onboarding(user, steps, ENV.currentStep)
-        @onboarding.onStepChanged (step) => @handleStepChanged(step)
-        @onboarding.onStepFailed (step, err) => @handleStepFailed(step, err)
-        @onboarding.onDone () => @handleTriggerDone()
+        onboarding = new Onboarding(user, steps, ENV.currentStep)
+        onboarding.onStepChanged (step) => @handleStepChanged(step)
+        onboarding.onStepFailed (step, err) => @handleStepFailed(step, err)
+        onboarding.onDone () => @handleTriggerDone()
+
+        return onboarding
+
+
+    # Handler for register route, display onboarding's current step
+    handleRegisterRoute: =>
+        @onboarding ?= @initializeOnboarding()
+
+        # Load onboarding stylesheet
+        AppStyles = require './styles/onboarding.styl'
 
         currentStep = @onboarding.getCurrentStep()
         @router.navigate currentStep.route

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -29,18 +29,7 @@ class App extends Application
     - layout: the application layout view, rendered.
     ###
     initialize: ->
-        steps = require './config/steps/all'
         @on 'start', =>
-
-            user = {
-                username: ENV.username,
-                hasValidInfos: ENV.hasValidInfos
-            }
-
-            @onboarding = new Onboarding(user, steps, ENV.currentStep)
-            @onboarding.onStepChanged (step) => @handleStepChanged(step)
-            @onboarding.onStepFailed (step, err) => @handleStepFailed(step, err)
-            @onboarding.onDone () => @handleTriggerDone()
 
             @initializeRouter()
 
@@ -58,10 +47,12 @@ class App extends Application
     # Backbone Router
     initializeRouter: () =>
         @router = new Router app: @
-        @router.route \
-            'register(/:step)',
-            'register',
-            @handleRegisterRoute
+        # if onboarding, the pathname will be '/register*'
+        if window.location.pathname.indexOf('/register') is 0
+            @router.route \
+                'register(/:step)',
+                'register',
+                @initializeOnboarding
 
 
     # Internal handler called when the onboarding's internal step has just
@@ -87,9 +78,21 @@ class App extends Application
 
 
     # Handler for register route, display onboarding's current step
-    handleRegisterRoute: =>
+    initializeOnboarding: =>
         # Load onboarding stylesheet
         AppStyles = require './styles/onboarding.styl'
+        # onboarding steps config
+        steps = require './config/steps/all'
+
+        user = {
+            username: ENV.username,
+            hasValidInfos: ENV.hasValidInfos
+        }
+
+        @onboarding = new Onboarding(user, steps, ENV.currentStep)
+        @onboarding.onStepChanged (step) => @handleStepChanged(step)
+        @onboarding.onStepFailed (step, err) => @handleStepFailed(step, err)
+        @onboarding.onDone () => @handleTriggerDone()
 
         currentStep = @onboarding.getCurrentStep()
         @router.navigate currentStep.route


### PR DESCRIPTION
This PR just split the initialisation code to prevent create the full onboarding component when it's not necessary.