### PR TITLE
Fix current step issue

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -87,7 +87,7 @@ class App extends Application
             apps: ENV.apps
         }
 
-        onboarding = new Onboarding(user, steps, ENV.currentStep)
+        onboarding = new Onboarding(user, steps, ENV.onboardedSteps)
         onboarding.onStepChanged (step) => @handleStepChanged(step)
         onboarding.onStepFailed (step, err) => @handleStepFailed(step, err)
         onboarding.onDone () => @handleTriggerDone()

--- a/client/app/lib/onboarding.coffee
+++ b/client/app/lib/onboarding.coffee
@@ -132,12 +132,13 @@ class Step
 module.exports = class Onboarding
 
 
-    constructor: (user, steps, currentStepName) ->
-        @initialize user, steps, currentStepName
+    constructor: (user, steps, onboardedSteps = []) ->
+        @initialize user, steps, onboardedSteps
 
 
-    initialize: (user, steps, currentStepName) ->
+    initialize: (user, steps, onboardedSteps) ->
         throw new Error 'Missing mandatory `steps` parameter' unless steps
+        throw new Error '`steps` parameter is empty' unless steps.length
 
         @user = user
         @steps = steps
@@ -150,10 +151,10 @@ module.exports = class Onboarding
                 return activeSteps
             , []
 
-        if currentStepName
-            @currentStep = @getStepByName currentStepName
-            if not @currentStep
-                throw new Error 'Given current step does not exist in step list'
+        @currentStep = @steps?.find (step) ->
+            return not (step.name in onboardedSteps)
+
+        @currentStep ?= @steps[0]
 
 
     # Records handler for 'stepChanged' pseudo-event, triggered when

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -140,6 +140,77 @@ describe('Onboarding', () => {
       assert.deepEqual(step2, onboarding.currentStep)
     });
 
+    it('should set first step as current step', () => {
+        // arrange
+        let user = null;
+        let steps = [{
+          name: 'test',
+          route: 'testroute',
+          view: 'testview'
+        }, {
+          name: 'test2',
+          route: 'testroute2',
+          view: 'testview2'
+        }];
+
+        let onboardedSteps = []
+
+        // act
+        let onboarding = new Onboarding(user, steps, onboardedSteps);
+        let step1 = onboarding.getStepByName('test');
+
+        // assert
+        assert.deepEqual(step1, onboarding.currentStep)
+    });
+
+    it('should set first step as current step with bad onboardedSteps', () => {
+        // arrange
+        let user = null;
+        let steps = [{
+          name: 'test',
+          route: 'testroute',
+          view: 'testview'
+        }, {
+          name: 'test2',
+          route: 'testroute2',
+          view: 'testview2'
+        }];
+
+        let onboardedSteps = ['test3', 'test4', 'test5']
+
+        // act
+        let onboarding = new Onboarding(user, steps, onboardedSteps);
+        let step1 = onboarding.getStepByName('test');
+
+        // assert
+        assert.deepEqual(step1, onboarding.currentStep)
+    });
+
+    it(
+        'should set first step as current step with completed onboardedSteps',
+        () => {
+            // arrange
+            let user = null;
+            let steps = [{
+              name: 'test',
+              route: 'testroute',
+              view: 'testview'
+            }, {
+              name: 'test2',
+              route: 'testroute2',
+              view: 'testview2'
+            }];
+
+            let onboardedSteps = ['test', 'test2']
+
+            // act
+            let onboarding = new Onboarding(user, steps, onboardedSteps);
+            let step1 = onboarding.getStepByName('test');
+
+            // assert
+            assert.deepEqual(step1, onboarding.currentStep)
+    });
+
     it('should throw an error if steps parameter is empty', () => {
       // arrange
       let user = null;

--- a/client/test/lib/onboarding.js
+++ b/client/test/lib/onboarding.js
@@ -14,7 +14,7 @@ describe('Onboarding', () => {
         lastname: 'Causi'
       };
 
-      let steps = [];
+      let steps = [{name: 'test'}];
 
       // act
       let onboarding = new Onboarding(user, steps);
@@ -130,36 +130,28 @@ describe('Onboarding', () => {
         view: 'testview2'
       }];
 
-      let step2Name = 'test2'
+      let onboardedSteps = ['test']
 
       // act
-      let onboarding = new Onboarding(user, steps, step2Name);
-      let step2 = onboarding.getStepByName(step2Name);
+      let onboarding = new Onboarding(user, steps, onboardedSteps);
+      let step2 = onboarding.getStepByName('test2');
 
       // assert
       assert.deepEqual(step2, onboarding.currentStep)
     });
 
-    it('should throw an error if given current step does not exist', () => {
+    it('should throw an error if steps parameter is empty', () => {
       // arrange
       let user = null;
-      let steps = [{
-        name: 'test',
-        route: 'testroute',
-        view: 'testview'
-      }, {
-        name: 'test2',
-        route: 'testroute2',
-        view: 'testview2'
-      }];
+      let steps = [];
 
       let fn = () => {
         // act
-        let onboarding = new Onboarding(user, steps, 'test3');
+        let onboarding = new Onboarding(user, steps);
       };
 
       // assert
-      assert.throw(fn, 'Given current step does not exist in step list');
+      assert.throw(fn, '`steps` parameter is empty');
     });
   });
 
@@ -167,7 +159,7 @@ describe('Onboarding', () => {
   describe('#onStepChanged', () => {
     it('should add given callback to step changed handlers', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       let callback = (step) => {};
 
       // act
@@ -181,7 +173,7 @@ describe('Onboarding', () => {
 
     it('should throw an error when callback is not a function', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       let randomString = 'abc';
       let fn = () => {
         // act
@@ -196,7 +188,7 @@ describe('Onboarding', () => {
   describe('#onStepFailed', () => {
     it('should add given callback to step failed handlers', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       let callback = (step) => {};
 
       // act
@@ -210,7 +202,7 @@ describe('Onboarding', () => {
 
     it('should throw an error when callback is not a function', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       let randomString = 'abc';
       let fn = () => {
         // act
@@ -225,7 +217,7 @@ describe('Onboarding', () => {
   describe('#onDone', () => {
     it('should add given callback to onDone handler', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       let callback = (step) => {};
 
       // act
@@ -239,7 +231,7 @@ describe('Onboarding', () => {
 
     it('should throw an error when callback is not a function', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       let randomString = 'abc';
       let fn = () => {
         // act
@@ -254,7 +246,7 @@ describe('Onboarding', () => {
   describe('#handleStepCompleted', () => {
     it('should call Onboarding#goToNext', () => {
       // arrange
-      let onboarding = new Onboarding(null, []);
+      let onboarding = new Onboarding(null, [{name: 'test'}]);
       onboarding.goToNext = sinon.spy();
 
       // act
@@ -267,7 +259,7 @@ describe('Onboarding', () => {
 
 
   describe('#goToNext', () => {
-    it('should call goToStep with first step', () => {
+    it('should call goToStep with second step', () => {
       // arrange
       let onboarding = new Onboarding(null, [
         {
@@ -281,7 +273,7 @@ describe('Onboarding', () => {
         }
       ]);
 
-      let firstStep = onboarding.steps[0];
+      let secondStep = onboarding.steps[1];
       onboarding.goToStep = sinon.spy();
 
       // act
@@ -289,7 +281,7 @@ describe('Onboarding', () => {
 
       // assert
       assert(onboarding.goToStep.calledOnce);
-      assert(onboarding.goToStep.calledWith(firstStep));
+      assert(onboarding.goToStep.calledWith(secondStep));
     });
 
     it('should call goToStep with next step', () => {

--- a/docs/client/onboarding.md
+++ b/docs/client/onboarding.md
@@ -29,7 +29,7 @@ However, it will be possible to override class methods in config objects (not im
 ##### Parameters
 * `user`: JS object representing user's properties
 * `steps`: Array of JS object representing steps
-* `currentStepName`: String reprensenting the current (or first) step in onboarding.
+* `onboardedSteps`: Array of string representing the list of step already done. Used to determine current step.
 
 Set the user and the steps list for the current onboarding.
 Called by the constructor method.

--- a/server/controllers/authentication.coffee
+++ b/server/controllers/authentication.coffee
@@ -67,7 +67,7 @@ module.exports.onboarding = (req, res, next) ->
                     # registration mode
                     # TODO: this one is temporary, and need to be removed
                     # when we merge CSS again.
-                    env.currentStep = User.getCurrentOnboardingStep userData
+                    env.onboardedSteps = userData?.onboardedSteps
                     res.render 'index', {env: env, onboarding: true}
 
 

--- a/server/models/user.coffee
+++ b/server/models/user.coffee
@@ -123,12 +123,6 @@ User.validatePassword = (password, errors = {}) ->
 
     return errors
 
-# Return the expected onboarding step for given userData
-User.getCurrentOnboardingStep = (userData) ->
-    return ONBOARDING_STEPS[0] unless userData and userData.onboardedSteps
-
-    return ONBOARDING_STEPS.find (step) ->
-        return userData.onboardedSteps.indexOf(step) is -1
 
 # Returns true if user is complete and is ready to log into his Cozy.
 # At this time this memthod check only if the user has completed all onboarding


### PR DESCRIPTION
With infos step and accounts step which may be both inactive, server may pass one of them as current step to client.
This causes an exception, because current step is not in onboarding's active steps list.

This PR fixes this issue, by delegating the decision of the current step to the client. To do so, it passes to it the full onboardedSteps list.