### PR TITLE
Add polyfills to support Array.find and Object.assign

### DIFF
--- a/client/app/initialize.coffee
+++ b/client/app/initialize.coffee
@@ -5,6 +5,8 @@ Sets the browser environment to prepare it to launch the app, and then require
 the application.
 ###
 
+require('./lib/polyfills')
+
 Polyglot = require 'node-polyglot'
 
 app = require './application'

--- a/client/app/lib/polyfills.js
+++ b/client/app/lib/polyfills.js
@@ -1,0 +1,52 @@
+// Array.find polyfill
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+     'use strict';
+     if (this == null) {
+       throw new TypeError('Array.prototype.find called on null or undefined');
+     }
+     if (typeof predicate !== 'function') {
+       throw new TypeError('predicate must be a function');
+     }
+     var list = Object(this);
+     var length = list.length >>> 0;
+     var thisArg = arguments[1];
+     var value;
+
+     for (var i = 0; i < length; i++) {
+       value = list[i];
+       if (predicate.call(thisArg, value, i, list)) {
+         return value;
+       }
+     }
+     return undefined;
+    }
+  });
+}
+
+// Object.assign polyfill
+if (typeof Object.assign != 'function') {
+  Object.assign = function (target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}


### PR DESCRIPTION
Add polyfills to support Array.find and Object.assign in older browsers.
Fix tested using Chromium v42