### PR TITLE
Fix /status/activated

### DIFF
--- a/server/lib/status_checker.coffee
+++ b/server/lib/status_checker.coffee
@@ -40,7 +40,7 @@ class StatusChecker
             @getChecker "proxy", proxyUrl, "routes"
         ], =>
             User.first (err, user) =>
-                if not user? or err
+                if not user?.activated? or err
                     callback null, @status
                 else
                     @status.registered = true


### PR DESCRIPTION
We are now able to create user when creating the server. /status/registered value was wrong for this users.